### PR TITLE
Hwde oprb v0.0.7

### DIFF
--- a/data/objects.xml
+++ b/data/objects.xml
@@ -6024,7 +6024,7 @@
 		<MovementType>Land</MovementType>
 		<Hardpoint name="Turret" autocenter="true" yawrate="45" pitchrate="60" pitchMinAngle="-5" pitchMaxAngle="90" yawattachment="turret" pitchattachment="cannon" />
 		<Hardpoint name="LockdownTurret" autocenter="true" yawrate="45" pitchrate="60" pitchMinAngle="-5" pitchMaxAngle="90" yawattachment="LockdownTurret" pitchattachment="LockdownCannon" />
-		<Velocity>13</Velocity>
+		<Velocity>6</Velocity>
 		<TurnRate>180</TurnRate>
 		<Hitpoints>8550</Hitpoints>
 		<AttackGradeDPS>190.9.0</AttackGradeDPS>

--- a/data/squads.xml
+++ b/data/squads.xml
@@ -1410,8 +1410,8 @@
 		<BuildPoints>60</BuildPoints>
 		<Cost resourcetype="Supplies">400</Cost>
 		<SubSelectSort>2000</SubSelectSort>
-		<LeashDistance>80</LeashDistance>
-		<LeashDeadzone>80</LeashDeadzone>
+		<LeashDistance>20</LeashDistance>
+		<LeashDeadzone>40</LeashDeadzone>
 		<LeashRecallDelay>2500</LeashRecallDelay>
 		<AggroDistance>40</AggroDistance>
 		<Birth anim0="Train" trainerAnim="Research" spawnpoint="bone_spawnPoint01" endPoint="bone_spawnPoint01">Trained</Birth>

--- a/data/tactics/unsc_veh_grizzly_01.tactics
+++ b/data/tactics/unsc_veh_grizzly_01.tactics
@@ -9,16 +9,16 @@
 		<ImpactEffect size="Medium">unsc_rifle_01</ImpactEffect>
 		<MaxVelocityLead>15</MaxVelocityLead>
 		<MaxRange>60</MaxRange>
-		<Accuracy>0.100000001</Accuracy>
+		<Accuracy>0.4</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
-		<MovingAccuracy>0.0500000007</MovingAccuracy>
+		<MovingAccuracy>0.2</MovingAccuracy>
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
 		<EnableHeightBonusDamage />
-		<TargetPriority type="Infantry">10</TargetPriority>
+		<TargetPriority type="GroundVehicle">10</TargetPriority>
 		<TargetPriority type="Flying">5</TargetPriority>
-		<TargetPriority type="GroundVehicle">0</TargetPriority>
+		<TargetPriority type="Infantry">0</TargetPriority>
 		<TargetPriority type="Building">-3</TargetPriority>
 		<Hardpoint>MGTurret</Hardpoint>
 	</Weapon>
@@ -31,7 +31,7 @@
 		<ImpactEffect size="Medium">tankshell_02</ImpactEffect>
 		<MaxVelocityLead>20</MaxVelocityLead>
 		<MaxRange>60</MaxRange>
-		<Accuracy>0.400000006</Accuracy>
+		<Accuracy>0.7</Accuracy>
 		<MaxDeviation>5</MaxDeviation>
 		<MovingAccuracy>0.400000006</MovingAccuracy>
 		<MovingMaxDeviation>7</MovingMaxDeviation>
@@ -59,14 +59,14 @@
 	<Weapon>
 		<Name>specialAttack</Name>
 		<AttackRate>30</AttackRate>
-		<DamagePerSecond>2000</DamagePerSecond>
+		<DamagePerSecond>2500</DamagePerSecond>
 		<UseDPSasDPA />
 		<WeaponType>SmallArms</WeaponType>
 		<Projectile>fx_proj_canistershell_01</Projectile>
 		<ImpactEffect size="Medium">canisterblast</ImpactEffect>
 		<MaxVelocityLead>20</MaxVelocityLead>
 		<MaxRange>80</MaxRange>
-		<Accuracy>0.200000003</Accuracy>
+		<Accuracy>0.5</Accuracy>
 		<MaxDeviation>7</MaxDeviation>
 		<MovingAccuracy>0.100000001</MovingAccuracy>
 		<MovingMaxDeviation>10</MovingMaxDeviation>


### PR DESCRIPTION
This release fixes the change to the Arbiter to make him actually not engage unless attacked at close range or ordered to attack. It also changes the following:

- Cobra recieves a 50% movement reduction to make it more of a defensive unit.
- Grizzly has had it's accuracy tweaked to make it's machine gun and turrets more accurate.
- Grizzly cannister shell gets 500 damage boost to allow it to be more effective against infantry.