### PR TITLE
Hwde oprb v0.0.8

### DIFF
--- a/data/gamedata.xml
+++ b/data/gamedata.xml
@@ -11,10 +11,10 @@
 		<Rate>Power</Rate>
 		<Rate>LeaderPowerCharge</Rate>
 	</Rates>
-	<UnscSupplyPadBonus>0.75</UnscSupplyPadBonus>
-	<UnscSupplyPadBreakEvenPoint>6.5</UnscSupplyPadBreakEvenPoint>
-	<CovSupplyPadBonus>0.75</CovSupplyPadBonus>
-	<CovSupplyPadBreakEvenPoint>6.5</CovSupplyPadBreakEvenPoint>
+	<UnscSupplyPadBonus>20.0</UnscSupplyPadBonus>
+	<UnscSupplyPadBreakEvenPoint>1.0</UnscSupplyPadBreakEvenPoint>
+	<CovSupplyPadBonus>20.0</CovSupplyPadBonus>
+	<CovSupplyPadBreakEvenPoint>1.0</CovSupplyPadBreakEvenPoint>
 	<LeaderPowerChargeResource>LeaderPowerCharge</LeaderPowerChargeResource>
 	<LeaderPowerChargeRate>LeaderPowerCharge</LeaderPowerChargeRate>
 	<DifficultyEasy>0</DifficultyEasy>

--- a/data/gamedata.xml
+++ b/data/gamedata.xml
@@ -11,10 +11,10 @@
 		<Rate>Power</Rate>
 		<Rate>LeaderPowerCharge</Rate>
 	</Rates>
-	<UnscSupplyPadBonus>20.0</UnscSupplyPadBonus>
-	<UnscSupplyPadBreakEvenPoint>1.0</UnscSupplyPadBreakEvenPoint>
-	<CovSupplyPadBonus>20.0</CovSupplyPadBonus>
-	<CovSupplyPadBreakEvenPoint>1.0</CovSupplyPadBreakEvenPoint>
+	<UnscSupplyPadBonus>1.0</UnscSupplyPadBonus>
+	<UnscSupplyPadBreakEvenPoint>20.0</UnscSupplyPadBreakEvenPoint>
+	<CovSupplyPadBonus>1.0</CovSupplyPadBonus>
+	<CovSupplyPadBreakEvenPoint>20.0</CovSupplyPadBreakEvenPoint>
 	<LeaderPowerChargeResource>LeaderPowerCharge</LeaderPowerChargeResource>
 	<LeaderPowerChargeRate>LeaderPowerCharge</LeaderPowerChargeRate>
 	<DifficultyEasy>0</DifficultyEasy>

--- a/data/tactics/cov_bldg_supplydepot_01.tactics
+++ b/data/tactics/cov_bldg_supplydepot_01.tactics
@@ -5,7 +5,7 @@
 		<ActionType>Gather</ActionType>
 		<Anim>Gather</Anim>
 		<Resource>Supplies</Resource>
-		<WorkRate>2.5</WorkRate>
+		<WorkRate>1.0</WorkRate>
 		<WorkRange>1</WorkRange>
 		<TeamShare />
 	</Action>

--- a/data/tactics/unsc_bldg_supplypad_01.tactics
+++ b/data/tactics/unsc_bldg_supplypad_01.tactics
@@ -5,7 +5,7 @@
 		<ActionType>Gather</ActionType>
 		<Anim>Gather</Anim>
 		<Resource>Supplies</Resource>
-		<WorkRate>2.5</WorkRate>
+		<WorkRate>1.0</WorkRate>
 		<WorkRange>1</WorkRange>
 	</Action>
 	<Tactic>


### PR DESCRIPTION
Alters the economy of the game in the following ways.

- Removed the 75% debuff per supply pad added such that building 2 supply pads now generates 2 times the income.
- Upped the threshold beyon which constucting more supply pads is meaningless from 6.5 to 20, rewarding strong economies and map control.
- Lowered the workrate of the basic supply pad to make it more appealing to upgrade, or hoard crates in the early game.