### PR TITLE
Marine/ODST rebalance

### DIFF
--- a/data/objects.xml
+++ b/data/objects.xml
@@ -5576,7 +5576,7 @@
 		<Velocity>10</Velocity>
 		<Acceleration>26</Acceleration>
 		<TurnRate>540</TurnRate>
-		<Hitpoints>720</Hitpoints>
+		<Hitpoints>820</Hitpoints>
 		<AttackGradeDPS>15</AttackGradeDPS>
 		<CombatValue>0.800000012</CombatValue>
 		<LOS>55</LOS>

--- a/data/powers.xml
+++ b/data/powers.xml
@@ -605,7 +605,7 @@
 	<Power name="UnscOdstDrop">
 		<Attributes>
 			<PowerType>ODST</PowerType>
-			<Cost Supplies="100" Power="3" />
+			<Cost Supplies="400" Power="4" />
 			<Pop type="Unit">1</Pop>
 			<AutoRecharge>10000</AutoRecharge>
 			<SequentialRecharge />

--- a/data/stringtable-en.xml
+++ b/data/stringtable-en.xml
@@ -165,8 +165,8 @@
 		<String _locID="1013" category="Techs" subtitle="false">Adds a light auto-cannon to all Elephants. This turret is only operable when the Elephant is deployed.</String>
 		<String _locID="1014" category="Techs" subtitle="false">NEW BLOOD</String>
 		<String _locID="1015" category="Techs" subtitle="false">Adds another Marine to the squad. This increases the combat effectiveness of the squad.</String>
-		<String _locID="1016" category="Techs" subtitle="false">RPG ABILITY</String>
-		<String _locID="1017" category="Techs" subtitle="false">Marine active Grenade Ability upgraded to active Rocket Ability. Rockets can attack from a longer range than Grenades.</String>
+		<String _locID="1016" category="Techs" subtitle="false">RPG</String>
+		<String _locID="1017" category="Techs" subtitle="false">Marine squads are issued Rocket Launchers. Rockets are automatically deployed when attacking air units.</String>
 		<String _locID="1018" category="Techs" subtitle="false" />
 		<String _locID="1019" category="Techs" subtitle="false" />
 		<String _locID="1020" category="Techs" subtitle="false" />
@@ -196,7 +196,7 @@
 		<String _locID="1044" category="Techs" subtitle="false">Hawk 2</String>
 		<String _locID="1045" category="Techs" subtitle="false">Improves Hawk damage and defense.</String>
 		<String _locID="1046" category="Techs" subtitle="false">MEDIC</String>
-		<String _locID="1047" category="Techs" subtitle="false">Adds a Combat Medic to the squad. The Medic heals the squad after combat.</String>
+		<String _locID="1047" category="Techs" subtitle="false">Adds a Combat Medic to the squad. The Medic heals the squad after combat, and uses a Rocket Launcher instead of the Grenade ability.</String>
 		<String _locID="1048" category="Techs" subtitle="false">COBRA 1</String>
 		<String _locID="1049" category="Techs" subtitle="false">Improves Cobra damage and defense (for now).</String>
 		<String _locID="1050" category="Techs" subtitle="false">DEFLECTION PLATING</String>

--- a/data/tactics/unsc_inf_marine_01.tactics
+++ b/data/tactics/unsc_inf_marine_01.tactics
@@ -176,20 +176,10 @@
 		<Name>RocketAttackAction</Name>
 		<ActionType>RangedAttack</ActionType>
 		<Anim>RocketAttack</Anim>
-		<SupportAnim>Support</SupportAnim>
 		<Weapon>RocketWeapon</Weapon>
+		<BaseDPSWeapon>AssaultRifle</BaseDPSWeapon>
 		<MainAttack />
-		<DontLoopAttackAnim />
-		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
-		<StartDisabled />
-	</Action>
-	<Action>
-		<Name>GrenadeAttackAction</Name>
-		<ActionType>RangedAttack</ActionType>
-		<Anim>FragGrenadeAttack</Anim>
-		<SupportAnim>Support</SupportAnim>
-		<Weapon>Grenade</Weapon>
-		<MainAttack />
+		<StartDisabled/>
 		<DontLoopAttackAnim />
 		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
 	</Action>
@@ -200,6 +190,17 @@
 		<ReloadAnim>AssaultRifleReload</ReloadAnim>
 		<Weapon>AssaultRifle</Weapon>
 		<MainAttack />
+		<FindBetterAction />
+	</Action>
+	<Action>
+		<Name>GrenadeAttackAction</Name>
+		<ActionType>RangedAttack</ActionType>
+		<Anim>FragGrenadeAttack</Anim>
+		<SupportAnim>Support</SupportAnim>
+		<Weapon>Grenade</Weapon>
+		<MainAttack />
+		<DontLoopAttackAnim />
+		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
 	</Action>
 	<Action>
 		<Name>GatherSupplies</Name>
@@ -335,7 +336,8 @@
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>
 		<TargetRule>
-			<Ability>Command</Ability>
+			<Relation>Enemy</Relation>
+			<TargetType>Flying</TargetType>
 			<Action>RocketAttackAction</Action>
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>

--- a/data/tactics/unsc_inf_odst_01.tactics
+++ b/data/tactics/unsc_inf_odst_01.tactics
@@ -71,6 +71,31 @@
 		<SmallArmsDeflectable />
 	</Weapon>
 	<Weapon>
+		<Name>Grenade</Name>
+		<AttackRate>0.5</AttackRate>
+		<DamagePerSecond>280</DamagePerSecond>
+		<UseDPSasDPA />
+		<WeaponType>Grenade</WeaponType>
+		<Projectile>fx_proj_grenade_01</Projectile>
+		<ImpactEffect size="Medium">tankshell</ImpactEffect>
+		<MaxVelocityLead>40</MaxVelocityLead>
+		<MaxRange>35</MaxRange>
+		<Accuracy>0.300000012</Accuracy>
+		<MaxDeviation>4</MaxDeviation>
+		<MovingAccuracy>0.300000012</MovingAccuracy>
+		<MovingMaxDeviation>4</MovingMaxDeviation>
+		<AOERadius>4</AOERadius>
+		<AOEPrimaryTargetFactor>0</AOEPrimaryTargetFactor>
+		<AOEDistanceFactor>0.25</AOEDistanceFactor>
+		<AOEDamageFactor>0.5</AOEDamageFactor>
+		<ThrowUnits />
+		<PhysicsLaunchAngleMin>15</PhysicsLaunchAngleMin>
+		<PhysicsLaunchAngleMax>75</PhysicsLaunchAngleMax>
+		<PhysicsForceMin>900</PhysicsForceMin>
+		<PhysicsForceMax>1100</PhysicsForceMax>
+		<Dodgeable />
+	</Weapon>
+	<Weapon>
 		<Name>RocketWeapon</Name>
 		<AttackRate>0.5</AttackRate>
 		<DamagePerSecond>280</DamagePerSecond>
@@ -119,6 +144,16 @@
 		<MainAttack />
 	</Action>
 	<Action>
+		<Name>GrenadeAttackAction</Name>
+		<ActionType>RangedAttack</ActionType>
+		<Anim>FragGrenadeAttack</Anim>
+		<SupportAnim>Support</SupportAnim>
+		<Weapon>Grenade</Weapon>
+		<MainAttack />
+		<DontLoopAttackAnim />
+		<MaxNumUnitsPerformAction>4</MaxNumUnitsPerformAction>
+	</Action>
+	<Action>
 		<Name>RocketAttackAction</Name>
 		<ActionType>RangedAttack</ActionType>
 		<Anim>RocketAttack</Anim>
@@ -126,7 +161,7 @@
 		<Weapon>RocketWeapon</Weapon>
 		<MainAttack />
 		<DontLoopAttackAnim />
-		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
+		<MaxNumUnitsPerformAction>3</MaxNumUnitsPerformAction>
 	</Action>
 	<Action>
 		<Name>GatherSupplies</Name>
@@ -246,12 +281,19 @@
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
+			<TargetType>Flying</TargetType>
+			<Action>RocketAttackAction</Action>
+			<SquadMode>Normal</SquadMode>
+		</TargetRule>		
+		<TargetRule>
+			<Relation>Enemy</Relation>
 			<Action>ShotgunAttackAction</Action>
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>
 		<TargetRule>
 			<Ability>Command</Ability>
-			<Action>RocketAttackAction</Action>
+			<TargetType>NonFlying</TargetType>
+			<Action>GrenadeAttackAction</Action>
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>
 		<TargetRule>

--- a/data/techs.xml
+++ b/data/techs.xml
@@ -1657,10 +1657,10 @@
 			<Effect type="Data" amount="1.25" subtype="Hitpoints" relativity="Percent">
 				<Target type="ProtoUnit">unsc_inf_medic_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_01</Target>
 			</Effect>
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="RocketAttackAction" relativity="Absolute">
@@ -1669,10 +1669,10 @@
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverRocketAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_02</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_02</Target>
 			</Effect>
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="RocketAttackAction" relativity="Absolute">
@@ -1681,10 +1681,10 @@
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverRocketAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_02</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_medic_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_medic_01</Target>
 			</Effect>
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="RocketAttackAction" relativity="Absolute">


### PR DESCRIPTION
Marines and ODSTs lose active RPG ability, and replace it with a passive ability against air. ODST costs increased as a balance.
ODSTs now need 4 tech maintained to deploy, and cost 400 to deploy to mitigate spam.