### PR TITLE
Hwde oprb v0.0.11

### DIFF
--- a/data/objects.xml
+++ b/data/objects.xml
@@ -5766,7 +5766,6 @@
 		<SubSelectSort>1000</SubSelectSort>
 		<SelectedRadiusX>1.29999995</SelectedRadiusX>
 		<SelectedRadiusZ>1.29999995</SelectedRadiusZ>
-		<AbilityCommand>UnscSpartanTakeOver</AbilityCommand>
 		<Sound Type="Create">play_unsc_spartan_birth</Sound>
 		<Sound Type="Select">play_unsc_spartan_select</Sound>
 		<Sound Type="Death">play_unsc_spartan_vo_death</Sound>

--- a/data/objects.xml
+++ b/data/objects.xml
@@ -5576,7 +5576,7 @@
 		<Velocity>10</Velocity>
 		<Acceleration>26</Acceleration>
 		<TurnRate>540</TurnRate>
-		<Hitpoints>720</Hitpoints>
+		<Hitpoints>820</Hitpoints>
 		<AttackGradeDPS>15</AttackGradeDPS>
 		<CombatValue>0.800000012</CombatValue>
 		<LOS>55</LOS>

--- a/data/objects.xml
+++ b/data/objects.xml
@@ -5167,10 +5167,10 @@
 		<DisplayNameID>10048</DisplayNameID>
 		<RolloverTextID>10049</RolloverTextID>
 		<MovementType>Land</MovementType>
-		<Velocity>12</Velocity>
+		<Velocity>15</Velocity>
 		<Acceleration>26</Acceleration>
 		<TurnRate>540</TurnRate>
-		<Hitpoints>1292</Hitpoints>
+		<Hitpoints>2000</Hitpoints>
 		<AttackGradeDPS>30</AttackGradeDPS>
 		<CombatValue>2</CombatValue>
 		<LOS>55</LOS>

--- a/data/powers.xml
+++ b/data/powers.xml
@@ -605,7 +605,7 @@
 	<Power name="UnscOdstDrop">
 		<Attributes>
 			<PowerType>ODST</PowerType>
-			<Cost Supplies="100" Power="3" />
+			<Cost Supplies="400" Power="4" />
 			<Pop type="Unit">1</Pop>
 			<AutoRecharge>10000</AutoRecharge>
 			<SequentialRecharge />

--- a/data/squads.xml
+++ b/data/squads.xml
@@ -35,7 +35,7 @@
 		<StatsNameID>25678</StatsNameID>
 		<PrereqTextID>232</PrereqTextID>
 		<RoleTextID>502</RoleTextID>
-		<BuildPoints>19</BuildPoints>
+		<BuildPoints>12</BuildPoints>
 		<Cost resourcetype="Supplies">250</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>7000</SubSelectSort>
@@ -66,7 +66,7 @@
 		<StatsNameID>25678</StatsNameID>
 		<PrereqTextID>233</PrereqTextID>
 		<RoleTextID>502</RoleTextID>
-		<BuildPoints>19</BuildPoints>
+		<BuildPoints>20</BuildPoints>
 		<Cost resourcetype="Supplies">250</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>7000</SubSelectSort>
@@ -127,7 +127,7 @@
 		<RolloverTextID>23671</RolloverTextID>
 		<PrereqTextID>231</PrereqTextID>
 		<RoleTextID>24068</RoleTextID>
-		<BuildPoints>40</BuildPoints>
+		<BuildPoints>25</BuildPoints>
 		<Cost resourcetype="Supplies">400</Cost>
 		<SubSelectSort>5201</SubSelectSort>
 		<LeashDistance>20</LeashDistance>
@@ -157,7 +157,7 @@
 		<StatsNameID>25680</StatsNameID>
 		<PrereqTextID>232</PrereqTextID>
 		<RoleTextID>501</RoleTextID>
-		<BuildPoints>36</BuildPoints>
+		<BuildPoints>18</BuildPoints>
 		<Cost resourcetype="Supplies">500</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>5200</SubSelectSort>
@@ -188,7 +188,7 @@
 		<StatsNameID>25680</StatsNameID>
 		<PrereqTextID>232</PrereqTextID>
 		<RoleTextID>501</RoleTextID>
-		<BuildPoints>36</BuildPoints>
+		<BuildPoints>18</BuildPoints>
 		<Cost resourcetype="Supplies">500</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>5200</SubSelectSort>
@@ -218,7 +218,7 @@
 		<RolloverTextID>3023</RolloverTextID>
 		<PrereqTextID>233</PrereqTextID>
 		<RoleTextID>505</RoleTextID>
-		<BuildPoints>22.5</BuildPoints>
+		<BuildPoints>20</BuildPoints>
 		<Cost resourcetype="Supplies">300</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>5100</SubSelectSort>
@@ -248,7 +248,7 @@
 		<RolloverTextID>3073</RolloverTextID>
 		<PrereqTextID>233</PrereqTextID>
 		<RoleTextID>504</RoleTextID>
-		<BuildPoints>26</BuildPoints>
+		<BuildPoints>20</BuildPoints>
 		<Cost resourcetype="Supplies">350</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>5075</SubSelectSort>
@@ -278,7 +278,7 @@
 		<RolloverTextID>3017</RolloverTextID>
 		<PrereqTextID>230</PrereqTextID>
 		<RoleTextID>518</RoleTextID>
-		<BuildPoints>22</BuildPoints>
+		<BuildPoints>10</BuildPoints>
 		<Cost resourcetype="Supplies">150</Cost>
 		<SubSelectSort>500</SubSelectSort>
 		<Birth anim0="Train" trainerAnim="TrainVehicles" spawnpoint="bone_spawnPoint01" endPoint="bone_endPoint01">Trained</Birth>
@@ -386,7 +386,7 @@
 		<MinimapScale>1</MinimapScale>
 		<DisplayNameID>23666</DisplayNameID>
 		<RolloverTextID>23667</RolloverTextID>
-		<BuildPoints>32</BuildPoints>
+		<BuildPoints>20</BuildPoints>
 		<RoleTextID>506</RoleTextID>
 		<Cost resourcetype="Supplies">200</Cost>
 		<Cost resourcetype="Power">1</Cost>
@@ -932,7 +932,7 @@
 		<RolloverTextID>3015</RolloverTextID>
 		<PrereqTextID>231</PrereqTextID>
 		<RoleTextID>519</RoleTextID>
-		<BuildPoints>16</BuildPoints>
+		<BuildPoints>20</BuildPoints>
 		<Cost resourcetype="Supplies">300</Cost>
 		<Cost resourcetype="Power">1</Cost>
 		<SubSelectSort>1000</SubSelectSort>

--- a/data/stringtable-en.xml
+++ b/data/stringtable-en.xml
@@ -165,8 +165,8 @@
 		<String _locID="1013" category="Techs" subtitle="false">Adds a light auto-cannon to all Elephants. This turret is only operable when the Elephant is deployed.</String>
 		<String _locID="1014" category="Techs" subtitle="false">NEW BLOOD</String>
 		<String _locID="1015" category="Techs" subtitle="false">Adds another Marine to the squad. This increases the combat effectiveness of the squad.</String>
-		<String _locID="1016" category="Techs" subtitle="false">RPG ABILITY</String>
-		<String _locID="1017" category="Techs" subtitle="false">Marine active Grenade Ability upgraded to active Rocket Ability. Rockets can attack from a longer range than Grenades.</String>
+		<String _locID="1016" category="Techs" subtitle="false">RPG</String>
+		<String _locID="1017" category="Techs" subtitle="false">Marine squads are issued Rocket Launchers. Rockets are automatically deployed when attacking air units.</String>
 		<String _locID="1018" category="Techs" subtitle="false" />
 		<String _locID="1019" category="Techs" subtitle="false" />
 		<String _locID="1020" category="Techs" subtitle="false" />
@@ -196,7 +196,7 @@
 		<String _locID="1044" category="Techs" subtitle="false">Hawk 2</String>
 		<String _locID="1045" category="Techs" subtitle="false">Improves Hawk damage and defense.</String>
 		<String _locID="1046" category="Techs" subtitle="false">MEDIC</String>
-		<String _locID="1047" category="Techs" subtitle="false">Adds a Combat Medic to the squad. The Medic heals the squad after combat.</String>
+		<String _locID="1047" category="Techs" subtitle="false">Adds a Combat Medic to the squad. The Medic heals the squad after combat, and uses a Rocket Launcher instead of the Grenade ability.</String>
 		<String _locID="1048" category="Techs" subtitle="false">COBRA 1</String>
 		<String _locID="1049" category="Techs" subtitle="false">Improves Cobra damage and defense (for now).</String>
 		<String _locID="1050" category="Techs" subtitle="false">DEFLECTION PLATING</String>

--- a/data/stringtable-en.xml
+++ b/data/stringtable-en.xml
@@ -1091,7 +1091,7 @@
 		<String _locID="22478" category="Techs" subtitle="false">CHAIN GUN</String>
 		<String _locID="22479" category="Techs" subtitle="false">Equips Spartans with two-handed auto-guns for dramatically increased damage.</String>
 		<String _locID="22480" category="Techs" subtitle="false">NEURAL IMPLANT</String>
-		<String _locID="22481" category="Techs" subtitle="false">Improved reflexes allow Spartans to Jack enemy vehicles much more effectively.</String>
+		<String _locID="22481" category="Techs" subtitle="false">The implantation of a smart AI to the MJOLNIR armour allows Spartans to take command of friendly and enemy vehicles, buffing them significantly.</String>
 		<String _locID="22482" category="Techs" subtitle="false">SPARTAN LASER</String>
 		<String _locID="22483" category="Techs" subtitle="false">The ultimate UNSC handheld weapon gives Spartans a distinct combat advantage.</String>
 		<String _locID="22484" category="Techs" subtitle="false">Grizzly 1</String>

--- a/data/tactics/cov_bldg_supplydepot_01.tactics
+++ b/data/tactics/cov_bldg_supplydepot_01.tactics
@@ -5,7 +5,7 @@
 		<ActionType>Gather</ActionType>
 		<Anim>Gather</Anim>
 		<Resource>Supplies</Resource>
-		<WorkRate>1.0</WorkRate>
+		<WorkRate>1.75</WorkRate>
 		<WorkRange>1</WorkRange>
 		<TeamShare />
 	</Action>

--- a/data/tactics/unsc_air_hawk_01.tactics
+++ b/data/tactics/unsc_air_hawk_01.tactics
@@ -19,9 +19,8 @@
 		<PhysicsLaunchAngleMax>15</PhysicsLaunchAngleMax>
 		<PhysicsForceMin>200</PhysicsForceMin>
 		<PhysicsForceMax>400</PhysicsForceMax>
-		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="Aircraft">10</TargetPriority>
 		<TargetPriority type="GroundVehicle">10</TargetPriority>
+		<TargetPriority type="Aircraft">8</TargetPriority>
 		<TargetPriority type="TurretBuilding">5</TargetPriority>
 		<TargetPriority type="Building">1</TargetPriority>
 		<Dodgeable />
@@ -37,15 +36,15 @@
 		<MaxVelocityLead>15</MaxVelocityLead>
 		<MaxRange>50</MaxRange>
 		<Hardpoint>MGTurretL</Hardpoint>
-		<Accuracy>0.100000001</Accuracy>
+		<Accuracy>0.2</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
 		<MovingAccuracy>0.0500000007</MovingAccuracy>
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
-		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="Aircraft">10</TargetPriority>
 		<TargetPriority type="GroundVehicle">10</TargetPriority>
+		<TargetPriority type="Aircraft">8</TargetPriority>
+		<TargetPriority type="Infantry">6</TargetPriority>
 		<TargetPriority type="TurretBuilding">5</TargetPriority>
 		<TargetPriority type="Building">1</TargetPriority>
 	</Weapon>
@@ -59,15 +58,15 @@
 		<MaxVelocityLead>15</MaxVelocityLead>
 		<MaxRange>50</MaxRange>
 		<Hardpoint>MGTurretR</Hardpoint>
-		<Accuracy>0.100000001</Accuracy>
+		<Accuracy>0.2</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
 		<MovingAccuracy>0.0500000007</MovingAccuracy>
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
-		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="Aircraft">10</TargetPriority>
 		<TargetPriority type="GroundVehicle">10</TargetPriority>
+		<TargetPriority type="Aircraft">8</TargetPriority>
+		<TargetPriority type="Infantry">6</TargetPriority>
 		<TargetPriority type="TurretBuilding">5</TargetPriority>
 		<TargetPriority type="Building">1</TargetPriority>
 	</Weapon>
@@ -81,7 +80,7 @@
 		<Hardpoint>ChaffTurret</Hardpoint>
 		<MaxVelocityLead>5</MaxVelocityLead>
 		<MaxRange>35</MaxRange>
-		<Accuracy>0.100000001</Accuracy>
+		<Accuracy>0.3</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
 	</Weapon>
 	<Action>

--- a/data/tactics/unsc_air_hornet_01.tactics
+++ b/data/tactics/unsc_air_hornet_01.tactics
@@ -2,7 +2,7 @@
 <TacticData>
 	<Weapon>
 		<Name>RocketLauncher</Name>
-		<AttackRate>6</AttackRate>
+		<AttackRate>10</AttackRate>
 		<DamagePerSecond>70.1500015</DamagePerSecond>
 		<WeaponType>Missile</WeaponType>
 		<Projectile>fx_proj_missile_01</Projectile>
@@ -19,9 +19,8 @@
 		<PhysicsLaunchAngleMax>15</PhysicsLaunchAngleMax>
 		<PhysicsForceMin>200</PhysicsForceMin>
 		<PhysicsForceMax>400</PhysicsForceMax>
-		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="Aircraft">10</TargetPriority>
 		<TargetPriority type="GroundVehicle">10</TargetPriority>
+		<TargetPriority type="Aircraft">8</TargetPriority>
 		<TargetPriority type="TurretBuilding">5</TargetPriority>
 		<TargetPriority type="Building">1</TargetPriority>
 		<Dodgeable />
@@ -68,6 +67,11 @@
 		<PhysicsLaunchAngleMax>75</PhysicsLaunchAngleMax>
 		<PhysicsForceMin>900</PhysicsForceMin>
 		<PhysicsForceMax>1100</PhysicsForceMax>
+		<TargetPriority type="GroundVehicle">10</TargetPriority>
+		<TargetPriority type="Aircraft">8</TargetPriority>
+		<TargetPriority type="TurretBuilding">5</TargetPriority>
+		<TargetPriority type="Building">1</TargetPriority>
+
 	</Weapon>
 	<Weapon>
 		<Name>RightWingMan</Name>
@@ -88,6 +92,10 @@
 		<PhysicsLaunchAngleMax>75</PhysicsLaunchAngleMax>
 		<PhysicsForceMin>900</PhysicsForceMin>
 		<PhysicsForceMax>1100</PhysicsForceMax>
+		<TargetPriority type="GroundVehicle">10</TargetPriority>
+		<TargetPriority type="Aircraft">8</TargetPriority>
+		<TargetPriority type="TurretBuilding">5</TargetPriority>
+		<TargetPriority type="Building">1</TargetPriority>
 	</Weapon>
 	<Weapon>
 		<Name>ChaffWeapon</Name>
@@ -98,7 +106,7 @@
 		<Hardpoint>ChaffTurret</Hardpoint>
 		<MaxVelocityLead>5</MaxVelocityLead>
 		<MaxRange>35</MaxRange>
-		<Accuracy>0.100000001</Accuracy>
+		<Accuracy>0.3</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
 	</Weapon>
 	<Action>

--- a/data/tactics/unsc_bldg_supplypad_01.tactics
+++ b/data/tactics/unsc_bldg_supplypad_01.tactics
@@ -5,7 +5,7 @@
 		<ActionType>Gather</ActionType>
 		<Anim>Gather</Anim>
 		<Resource>Supplies</Resource>
-		<WorkRate>1.0</WorkRate>
+		<WorkRate>1.75</WorkRate>
 		<WorkRange>1</WorkRange>
 	</Action>
 	<Tactic>

--- a/data/tactics/unsc_inf_flamemarine_01.tactics
+++ b/data/tactics/unsc_inf_flamemarine_01.tactics
@@ -15,8 +15,6 @@
 		<AOEDistanceFactor>0.75</AOEDistanceFactor>
 		<AOEDamageFactor>0.75</AOEDamageFactor>
 		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Building">3</TargetPriority>
 		<Hardpoint>Torso</Hardpoint>
 	</Weapon>
 	<Weapon>
@@ -34,8 +32,6 @@
 		<AOEDistanceFactor>0.75</AOEDistanceFactor>
 		<AOEDamageFactor>0.75</AOEDamageFactor>
 		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Building">3</TargetPriority>
 		<Hardpoint>Torso</Hardpoint>
 	</Weapon>
 	<Weapon>
@@ -53,8 +49,6 @@
 		<AOEDistanceFactor>0.75</AOEDistanceFactor>
 		<AOEDamageFactor>0.75</AOEDamageFactor>
 		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Building">3</TargetPriority>
 		<Hardpoint>Torso</Hardpoint>
 	</Weapon>
 	<Weapon>
@@ -72,8 +66,6 @@
 		<AOEDistanceFactor>0.75</AOEDistanceFactor>
 		<AOEDamageFactor>0.75</AOEDamageFactor>
 		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Building">3</TargetPriority>
 		<Hardpoint>Torso</Hardpoint>
 	</Weapon>
 	<Weapon>

--- a/data/tactics/unsc_inf_marine_01.tactics
+++ b/data/tactics/unsc_inf_marine_01.tactics
@@ -176,20 +176,10 @@
 		<Name>RocketAttackAction</Name>
 		<ActionType>RangedAttack</ActionType>
 		<Anim>RocketAttack</Anim>
-		<SupportAnim>Support</SupportAnim>
 		<Weapon>RocketWeapon</Weapon>
+		<BaseDPSWeapon>AssaultRifle</BaseDPSWeapon>
 		<MainAttack />
-		<DontLoopAttackAnim />
-		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
-		<StartDisabled />
-	</Action>
-	<Action>
-		<Name>GrenadeAttackAction</Name>
-		<ActionType>RangedAttack</ActionType>
-		<Anim>FragGrenadeAttack</Anim>
-		<SupportAnim>Support</SupportAnim>
-		<Weapon>Grenade</Weapon>
-		<MainAttack />
+		<StartDisabled/>
 		<DontLoopAttackAnim />
 		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
 	</Action>
@@ -200,6 +190,17 @@
 		<ReloadAnim>AssaultRifleReload</ReloadAnim>
 		<Weapon>AssaultRifle</Weapon>
 		<MainAttack />
+		<FindBetterAction />
+	</Action>
+	<Action>
+		<Name>GrenadeAttackAction</Name>
+		<ActionType>RangedAttack</ActionType>
+		<Anim>FragGrenadeAttack</Anim>
+		<SupportAnim>Support</SupportAnim>
+		<Weapon>Grenade</Weapon>
+		<MainAttack />
+		<DontLoopAttackAnim />
+		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
 	</Action>
 	<Action>
 		<Name>GatherSupplies</Name>
@@ -335,7 +336,8 @@
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>
 		<TargetRule>
-			<Ability>Command</Ability>
+			<Relation>Enemy</Relation>
+			<TargetType>Flying</TargetType>
 			<Action>RocketAttackAction</Action>
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>

--- a/data/tactics/unsc_inf_odst_01.tactics
+++ b/data/tactics/unsc_inf_odst_01.tactics
@@ -71,6 +71,31 @@
 		<SmallArmsDeflectable />
 	</Weapon>
 	<Weapon>
+		<Name>Grenade</Name>
+		<AttackRate>0.5</AttackRate>
+		<DamagePerSecond>280</DamagePerSecond>
+		<UseDPSasDPA />
+		<WeaponType>Grenade</WeaponType>
+		<Projectile>fx_proj_grenade_01</Projectile>
+		<ImpactEffect size="Medium">tankshell</ImpactEffect>
+		<MaxVelocityLead>40</MaxVelocityLead>
+		<MaxRange>35</MaxRange>
+		<Accuracy>0.300000012</Accuracy>
+		<MaxDeviation>4</MaxDeviation>
+		<MovingAccuracy>0.300000012</MovingAccuracy>
+		<MovingMaxDeviation>4</MovingMaxDeviation>
+		<AOERadius>4</AOERadius>
+		<AOEPrimaryTargetFactor>0</AOEPrimaryTargetFactor>
+		<AOEDistanceFactor>0.25</AOEDistanceFactor>
+		<AOEDamageFactor>0.5</AOEDamageFactor>
+		<ThrowUnits />
+		<PhysicsLaunchAngleMin>15</PhysicsLaunchAngleMin>
+		<PhysicsLaunchAngleMax>75</PhysicsLaunchAngleMax>
+		<PhysicsForceMin>900</PhysicsForceMin>
+		<PhysicsForceMax>1100</PhysicsForceMax>
+		<Dodgeable />
+	</Weapon>
+	<Weapon>
 		<Name>RocketWeapon</Name>
 		<AttackRate>0.5</AttackRate>
 		<DamagePerSecond>280</DamagePerSecond>
@@ -119,6 +144,16 @@
 		<MainAttack />
 	</Action>
 	<Action>
+		<Name>GrenadeAttackAction</Name>
+		<ActionType>RangedAttack</ActionType>
+		<Anim>FragGrenadeAttack</Anim>
+		<SupportAnim>Support</SupportAnim>
+		<Weapon>Grenade</Weapon>
+		<MainAttack />
+		<DontLoopAttackAnim />
+		<MaxNumUnitsPerformAction>4</MaxNumUnitsPerformAction>
+	</Action>
+	<Action>
 		<Name>RocketAttackAction</Name>
 		<ActionType>RangedAttack</ActionType>
 		<Anim>RocketAttack</Anim>
@@ -126,7 +161,7 @@
 		<Weapon>RocketWeapon</Weapon>
 		<MainAttack />
 		<DontLoopAttackAnim />
-		<MaxNumUnitsPerformAction>2</MaxNumUnitsPerformAction>
+		<MaxNumUnitsPerformAction>3</MaxNumUnitsPerformAction>
 	</Action>
 	<Action>
 		<Name>GatherSupplies</Name>
@@ -246,12 +281,19 @@
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
+			<TargetType>Flying</TargetType>
+			<Action>RocketAttackAction</Action>
+			<SquadMode>Normal</SquadMode>
+		</TargetRule>		
+		<TargetRule>
+			<Relation>Enemy</Relation>
 			<Action>ShotgunAttackAction</Action>
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>
 		<TargetRule>
 			<Ability>Command</Ability>
-			<Action>RocketAttackAction</Action>
+			<TargetType>NonFlying</TargetType>
+			<Action>GrenadeAttackAction</Action>
 			<SquadMode>Normal</SquadMode>
 		</TargetRule>
 		<TargetRule>

--- a/data/tactics/unsc_inf_spartan_01.tactics
+++ b/data/tactics/unsc_inf_spartan_01.tactics
@@ -123,6 +123,7 @@
 		<JoinType>Merge</JoinType>
 		<MergeType>Ground</MergeType>
 		<DamageModifiers damage="1.39999998" damageTaken="0.713999987" />
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>VehicleJoin</Name>
@@ -132,6 +133,7 @@
 		<ProtoObject>fx_hijacked</ProtoObject>
 		<JoinType revertDamagePct="0.5" veterancyOverride="true" levels="1" unjoinMaxDist="25">Board</JoinType>
 		<DamageModifiers damage="1.14999998" damageTaken="0.870000005" byCombatValue="false" />
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>VehicleTakeOver</Name>
@@ -155,6 +157,7 @@
 		<Fatality attacker="HijackCobraStart" attackerEnd="HijackCobraEnd" target="Idle" targetEnd="SpartanCobraJack" boarding="true" offsetTolerance="15" transitionBeforeAnimating="false" transitionDelay="0.25" transitionTime="1" cooldown="0">unsc_veh_cobra_01</Fatality>
 		<Fatality attacker="HijackGremlinStart" attackerEnd="HijackGremlinEnd" target="Idle" targetEnd="SpartanGremlinJack" boarding="true" offsetTolerance="15" transitionBeforeAnimating="false" transitionDelay="0.25" transitionTime="1" cooldown="0">unsc_veh_gremlin_01</Fatality>
 		<Fatality attacker="HijackGrizzlyStart" attackerEnd="HijackGrizzlyEnd" target="Idle" targetEnd="SpartanGrizzlyJack" boarding="true" offsetTolerance="15" transitionBeforeAnimating="false" transitionDelay="0.25" transitionTime="0.5" cooldown="0">unsc_veh_grizzly_01</Fatality>
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>AircraftTakeOver</Name>
@@ -168,6 +171,7 @@
 		<Fatality attacker="HijackVampireStart" attackerEnd="HijackVampireEnd" target="Idle" targetEnd="SpartanVampireJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">cov_air_vampire_01</Fatality>
 		<Fatality attacker="HijackHawkStart" attackerEnd="HijackHawkEnd" target="Idle" targetEnd="SpartanHawkJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">unsc_air_hawk_01</Fatality>
 		<Fatality attacker="HijackHornetStart" attackerEnd="HijackHornetEnd" target="Idle" targetEnd="SpartanHornetJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">unsc_air_hornet_01</Fatality>
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>GarrisonTeleport</Name>

--- a/data/tactics/unsc_inf_spartan_02.tactics
+++ b/data/tactics/unsc_inf_spartan_02.tactics
@@ -128,6 +128,7 @@
 		<JoinType>Merge</JoinType>
 		<MergeType>Ground</MergeType>
 		<DamageModifiers damage="1.39999998" damageTaken="0.713999987" />
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>VehicleJoin</Name>
@@ -137,6 +138,7 @@
 		<ProtoObject>fx_hijacked</ProtoObject>
 		<JoinType revertDamagePct="0.5" veterancyOverride="true" levels="2" unjoinMaxDist="25">Board</JoinType>
 		<DamageModifiers damage="1.29999995" damageTaken="0.769999981" byCombatValue="false" />
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>UpgradedVehicleJoin</Name>
@@ -170,6 +172,7 @@
 		<Fatality attacker="HijackCobraStart" attackerEnd="HijackCobraEnd" target="Idle" targetEnd="SpartanCobraJack" boarding="true" offsetTolerance="15" transitionBeforeAnimating="false" transitionDelay="0.25" transitionTime="1" cooldown="0">unsc_veh_cobra_01</Fatality>
 		<Fatality attacker="HijackGremlinStart" attackerEnd="HijackGremlinEnd" target="Idle" targetEnd="SpartanGremlinJack" boarding="true" offsetTolerance="15" transitionBeforeAnimating="false" transitionDelay="0.25" transitionTime="1" cooldown="0">unsc_veh_gremlin_01</Fatality>
 		<Fatality attacker="HijackGrizzlyStart" attackerEnd="HijackGrizzlyEnd" target="Idle" targetEnd="SpartanGrizzlyJack" boarding="true" offsetTolerance="15" transitionBeforeAnimating="false" transitionDelay="0.25" transitionTime="0.5" cooldown="0">unsc_veh_grizzly_01</Fatality>
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>AircraftTakeOver</Name>
@@ -183,6 +186,7 @@
 		<Fatality attacker="HijackVampireStart" attackerEnd="HijackVampireEnd" target="Idle" targetEnd="SpartanVampireJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">cov_air_vampire_01</Fatality>
 		<Fatality attacker="HijackHawkStart" attackerEnd="HijackHawkEnd" target="Idle" targetEnd="SpartanHawkJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">unsc_air_hawk_01</Fatality>
 		<Fatality attacker="HijackHornetStart" attackerEnd="HijackHornetEnd" target="Idle" targetEnd="SpartanHornetJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">unsc_air_hornet_01</Fatality>
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>UpgradedVehicleTakeOver</Name>
@@ -220,6 +224,7 @@
 		<Fatality attacker="HijackVampireStart" attackerEnd="HijackVampireEnd" target="Idle" targetEnd="SpartanVampireJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">cov_air_vampire_01</Fatality>
 		<Fatality attacker="HijackHawkStart" attackerEnd="HijackHawkEnd" target="Idle" targetEnd="SpartanHawkJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">unsc_air_hawk_01</Fatality>
 		<Fatality attacker="HijackHornetStart" attackerEnd="HijackHornetEnd" target="Idle" targetEnd="SpartanHornetJack" boarding="true" offsetTolerance="20" orientationOffset="360" transitionBeforeAnimating="false" cooldown="0" transitionDelay="0" transitionTime="0.800000012" toBoneRelative="true" air="true" airApexPercent="0.629999995" airHeight="8">unsc_air_hornet_01</Fatality>
+		<StartDisabled/>
 	</Action>
 	<Action>
 		<Name>GarrisonTeleport</Name>

--- a/data/tactics/unsc_veh_grizzly_01.tactics
+++ b/data/tactics/unsc_veh_grizzly_01.tactics
@@ -2,36 +2,34 @@
 <TacticData>
 	<Weapon>
 		<Name>Machinegun</Name>
-		<AttackRate>0.25</AttackRate>
+		<AttackRate>0.75</AttackRate>
 		<DamagePerSecond>136.350006</DamagePerSecond>
 		<WeaponType>SmallArms</WeaponType>
 		<Projectile>fx_proj_machineGun_01</Projectile>
 		<ImpactEffect size="Medium">unsc_rifle_01</ImpactEffect>
 		<MaxVelocityLead>15</MaxVelocityLead>
 		<MaxRange>60</MaxRange>
-		<Accuracy>0.4</Accuracy>
+		<Accuracy>0.5</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
 		<MovingAccuracy>0.2</MovingAccuracy>
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
 		<EnableHeightBonusDamage />
-		<TargetPriority type="GroundVehicle">10</TargetPriority>
 		<TargetPriority type="Flying">5</TargetPriority>
 		<TargetPriority type="Infantry">0</TargetPriority>
-		<TargetPriority type="Building">-3</TargetPriority>
 		<Hardpoint>MGTurret</Hardpoint>
 	</Weapon>
 	<Weapon>
 		<Name>Cannon</Name>
-		<AttackRate>3</AttackRate>
+		<AttackRate>4</AttackRate>
 		<DamagePerSecond>136.350006</DamagePerSecond>
 		<WeaponType>Explosive</WeaponType>
 		<Projectile>fx_proj_cannon_02</Projectile>
 		<ImpactEffect size="Medium">tankshell_02</ImpactEffect>
 		<MaxVelocityLead>20</MaxVelocityLead>
 		<MaxRange>60</MaxRange>
-		<Accuracy>0.7</Accuracy>
+		<Accuracy>0.9</Accuracy>
 		<MaxDeviation>5</MaxDeviation>
 		<MovingAccuracy>0.400000006</MovingAccuracy>
 		<MovingMaxDeviation>7</MovingMaxDeviation>
@@ -51,7 +49,6 @@
 		<PhysicsForceMaxAngle>0.800000012</PhysicsForceMaxAngle>
 		<TargetPriority type="GroundVehicle">10</TargetPriority>
 		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Infantry">3</TargetPriority>
 		<TargetPriority type="Building">1</TargetPriority>
 		<Dodgeable />
 		<Deflectable />

--- a/data/tactics/unsc_veh_scorpion_01.tactics
+++ b/data/tactics/unsc_veh_scorpion_01.tactics
@@ -2,7 +2,7 @@
 <TacticData>
 	<Weapon>
 		<Name>Machinegun</Name>
-		<AttackRate>0.25</AttackRate>
+		<AttackRate>0.5</AttackRate>
 		<DamagePerSecond>136.350006</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_machineGun_01</Projectile>
@@ -11,20 +11,18 @@
 		<MaxRange>60</MaxRange>
 		<Accuracy>0.100000001</Accuracy>
 		<MaxDeviation>4</MaxDeviation>
-		<MovingAccuracy>0.0500000007</MovingAccuracy>
+		<MovingAccuracy>0.1000000007</MovingAccuracy>
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
 		<EnableHeightBonusDamage />
 		<TargetPriority type="Infantry">10</TargetPriority>
 		<TargetPriority type="Flying">5</TargetPriority>
-		<TargetPriority type="GroundVehicle">0</TargetPriority>
-		<TargetPriority type="Building">-3</TargetPriority>
 		<Hardpoint>MGTurret</Hardpoint>
 	</Weapon>
 	<Weapon>
 		<Name>Cannon</Name>
-		<AttackRate>3</AttackRate>
+		<AttackRate>4</AttackRate>
 		<DamagePerSecond>136.350006</DamagePerSecond>
 		<WeaponType>Explosive</WeaponType>
 		<Projectile>fx_proj_cannon_01</Projectile>
@@ -51,7 +49,6 @@
 		<PhysicsForceMaxAngle>0.800000012</PhysicsForceMaxAngle>
 		<TargetPriority type="GroundVehicle">10</TargetPriority>
 		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Infantry">3</TargetPriority>
 		<TargetPriority type="Building">1</TargetPriority>
 		<Dodgeable />
 		<Deflectable />

--- a/data/tactics/unsc_veh_warthog_01.tactics
+++ b/data/tactics/unsc_veh_warthog_01.tactics
@@ -25,7 +25,7 @@
 	</Weapon>
 	<Weapon>
 		<Name>GaussCannon</Name>
-		<AttackRate>0.25</AttackRate>
+		<AttackRate>0.4</AttackRate>
 		<DamagePerSecond>119.699997</DamagePerSecond>
 		<WeaponType>GaussCannon</WeaponType>
 		<Projectile>fx_proj_gaussCannon_01</Projectile>
@@ -40,8 +40,8 @@
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
 		<EnableHeightBonusDamage />
 		<Hardpoint>Turret</Hardpoint>
-		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="Aircraft">5</TargetPriority>
+		<TargetPriority type="Aircraft">10</TargetPriority>
+		<TargetPriority type="Infantry">5</TargetPriority>
 		<TargetPriority type="GroundVehicle">1</TargetPriority>
 		<TargetPriority type="Building">-3</TargetPriority>
 	</Weapon>

--- a/data/tactics/unsc_veh_wolverine_01.tactics
+++ b/data/tactics/unsc_veh_wolverine_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>MissileLauncher</Name>
 		<AttackRate>6</AttackRate>
-		<DamagePerSecond>131.5</DamagePerSecond>
+		<DamagePerSecond>150</DamagePerSecond>
 		<WeaponType>AntiAir</WeaponType>
 		<Projectile>fx_proj_missile_01</Projectile>
 		<ImpactEffect size="Medium">unsc_rocket_01</ImpactEffect>
@@ -16,7 +16,7 @@
 	<Weapon>
 		<Name>UpgradedMissileLauncher</Name>
 		<AttackRate>12</AttackRate>
-		<DamagePerSecond>131.5</DamagePerSecond>
+		<DamagePerSecond>200</DamagePerSecond>
 		<WeaponType>AntiAir</WeaponType>
 		<Projectile>fx_proj_missile_01</Projectile>
 		<ImpactEffect size="Medium">unsc_rocket_01</ImpactEffect>

--- a/data/techs.xml
+++ b/data/techs.xml
@@ -2802,6 +2802,12 @@
 			<Effect type="Data" amount="1" subtype="Techlevel" allactions="1" relativity="Absolute">
 				<Target type="ProtoSquad">unsc_inf_spartan_01</Target>
 			</Effect>
+			<Effect type="Data" amount="1" subtype="AbilityDisabled" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="1" subtype="AbilityDisabled" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_02</Target>
+			</Effect>
 			<Effect type="TransformProtoUnit" FromType="unsc_inf_spartan_01" ToType="unsc_inf_spartan_02" />
 			<Effect type="Data" amount="1.25" subtype="Damage" allactions="1" relativity="Percent">
 				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
@@ -2814,6 +2820,24 @@
 			</Effect>
 			<Effect type="Data" subtype="Icon" iconType="unit" iconName="unsc_spartan_upgrade1">
 				<Target type="ProtoSquad">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="0" subtype="ActionEnable" action="VehicleTakeOver" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="0" subtype="ActionEnable" action="UpgradedVehicleTakeOver" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="0" subtype="ActionEnable" action="VehicleJoin" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="0" subtype="ActionEnable" action="UpgradedVehicleJoin" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="0" subtype="ActionEnable" action="AircraftTakeOver" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+			<Effect type="Data" amount="0" subtype="ActionEnable" action="UpgradedAircraftTakeOver" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
 			</Effect>
 		</Effects>
 	</Tech>
@@ -2865,6 +2889,10 @@
 			<Effect type="Data" subtype="Icon" iconType="unit" iconName="unsc_spartan_upgrade2">
 				<Target type="ProtoSquad">unsc_inf_spartan_01</Target>
 			</Effect>
+			<Effect type="Data" amount="0" subtype="AbilityDisabled" relativity="Absolute">
+				<Target type="ProtoUnit">unsc_inf_spartan_01</Target>
+			</Effect>
+
 		</Effects>
 	</Tech>
 	<Tech name="unsc_spartan_upgrade3" type="Normal" Alpha="0">

--- a/data/techs.xml
+++ b/data/techs.xml
@@ -1657,10 +1657,10 @@
 			<Effect type="Data" amount="1.25" subtype="Hitpoints" relativity="Percent">
 				<Target type="ProtoUnit">unsc_inf_medic_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_01</Target>
 			</Effect>
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="RocketAttackAction" relativity="Absolute">
@@ -1669,10 +1669,10 @@
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverRocketAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_02</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_02</Target>
 			</Effect>
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="RocketAttackAction" relativity="Absolute">
@@ -1681,10 +1681,10 @@
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverRocketAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_marine_02</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="GrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_medic_01</Target>
 			</Effect>
-			<Effect type="Data" amount="0" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
+			<Effect type="Data" amount="1" subtype="ActionEnable" action="InCoverGrenadeAttackAction" relativity="Absolute">
 				<Target type="ProtoUnit">unsc_inf_medic_01</Target>
 			</Effect>
 			<Effect type="Data" amount="1" subtype="ActionEnable" action="RocketAttackAction" relativity="Absolute">


### PR DESCRIPTION
Changes:

Build time reductions for:

- Warthog
- Hornet
- Elephant
- Scorpion
- Wolverine
- Grizzly
- Gremlin

Build time increase for:
- Spartan
- Hawk

- UNSC main air and tanks can now only use their machine guns against infantry, cannon and rockets are not allowed.
- Machine guns get a fire rate buff.
- Hornet and Hawk Chaff boost.
- Flamer gets a big speed boost and small health buff to make them more combat effective.
