### PR TITLE
fixed flying secondary turret issue - buffed Elephant turret damage

### DIFF
--- a/data/tactics/unsc_air_hawk_01.tactics
+++ b/data/tactics/unsc_air_hawk_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>Laser</Name>
 		<AttackRate>6</AttackRate>
-		<DamagePerSecond>70.1500015</DamagePerSecond>
+		<DamagePerSecond>100</DamagePerSecond>
 		<WeaponType>Missile</WeaponType>
 		<Projectile>fx_proj_hawkLaser_01</Projectile>
 		<ImpactEffect size="Medium">empgrenade</ImpactEffect>
@@ -42,11 +42,7 @@
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
-		<TargetPriority type="GroundVehicle">10</TargetPriority>
-		<TargetPriority type="Aircraft">8</TargetPriority>
 		<TargetPriority type="Infantry">6</TargetPriority>
-		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Building">1</TargetPriority>
 	</Weapon>
 	<Weapon>
 		<Name>RightMachinegun</Name>
@@ -64,11 +60,7 @@
 		<MovingMaxDeviation>6</MovingMaxDeviation>
 		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
-		<TargetPriority type="GroundVehicle">10</TargetPriority>
-		<TargetPriority type="Aircraft">8</TargetPriority>
 		<TargetPriority type="Infantry">6</TargetPriority>
-		<TargetPriority type="TurretBuilding">5</TargetPriority>
-		<TargetPriority type="Building">1</TargetPriority>
 	</Weapon>
 	<Weapon>
 		<Name>ChaffWeapon</Name>
@@ -92,17 +84,19 @@
 	</Action>
 	<Action>
 		<Name>LeftMachinegunAttackAction</Name>
-		<ActionType>SecondaryTurretAttack</ActionType>
+		<ActionType>RangedAttack</ActionType>
 		<PersistentActionType>SecondaryTurretAttack</PersistentActionType>
 		<Anim>MachinegunAttackL</Anim>
 		<Weapon>LeftMachinegun</Weapon>
+		<MainAttack />
 	</Action>
 	<Action>
 		<Name>RightMachinegunAttackAction</Name>
-		<ActionType>SecondaryTurretAttack</ActionType>
+		<ActionType>RangedAttack</ActionType>
 		<PersistentActionType>SecondaryTurretAttack</PersistentActionType>
 		<Anim>MachinegunAttackR</Anim>
 		<Weapon>RightMachinegun</Weapon>
+		<MainAttack />
 	</Action>
 	<Action>
 		<Name>AvoidCollisionAir</Name>
@@ -163,10 +157,12 @@
 		<TargetRule>
 			<Relation>Enemy</Relation>
 			<Action>LeftMachinegunAttackAction</Action>
+			<TargetType>Infantry</TargetType>
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
 			<Action>RightMachinegunAttackAction</Action>
+			<TargetType>Infantry</TargetType>
 		</TargetRule>
 		<TargetRule>
 			<GaiaOwned />

--- a/data/tactics/unsc_air_hornet_01.tactics
+++ b/data/tactics/unsc_air_hornet_01.tactics
@@ -122,10 +122,11 @@
 	</Action>
 	<Action>
 		<Name>MachinegunAttackAction</Name>
-		<ActionType>SecondaryTurretAttack</ActionType>
+		<ActionType>RangedAttack</ActionType>
 		<PersistentActionType>SecondaryTurretAttack</PersistentActionType>
 		<Anim>MachinegunAttack</Anim>
 		<Weapon>Machinegun</Weapon>
+		<MainAttack />
 	</Action>
 	<Action>
 		<Name>LeftWingmanAttackAction</Name>
@@ -203,6 +204,10 @@
 		<TargetRule>
 			<Relation>Enemy</Relation>
 			<Action>RocketLauncherAttackAction</Action>
+			<TargetType>GroundVehicle</TargetType>
+			<TargetType>Flying</TargetType>
+			<TargetType>Building</TargetType>
+			<TargetType>TurretBuilding</TargetType>
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
@@ -211,10 +216,18 @@
 		<TargetRule>
 			<Relation>Enemy</Relation>
 			<Action>LeftWingmanAttackAction</Action>
+			<TargetType>GroundVehicle</TargetType>
+			<TargetType>Flying</TargetType>
+			<TargetType>Building</TargetType>
+			<TargetType>TurretBuilding</TargetType>
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
 			<Action>RightWingmanAttackAction</Action>
+			<TargetType>GroundVehicle</TargetType>
+			<TargetType>Flying</TargetType>
+			<TargetType>Building</TargetType>
+			<TargetType>TurretBuilding</TargetType>
 		</TargetRule>
 		<TargetRule>
 			<GaiaOwned />

--- a/data/tactics/unsc_veh_elephant_02.tactics
+++ b/data/tactics/unsc_veh_elephant_02.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>FrontMG</Name>
 		<AttackRate>0.25</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
+		<DamagePerSecond>100</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_machinegun_01</Projectile>
 		<ImpactEffect size="Small">unsc_rifle_01</ImpactEffect>
@@ -25,7 +25,7 @@
 	<Weapon>
 		<Name>RightMG</Name>
 		<AttackRate>0.25</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
+		<DamagePerSecond>100</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_machinegun_01</Projectile>
 		<ImpactEffect size="Small">unsc_rifle_01</ImpactEffect>
@@ -47,7 +47,7 @@
 	<Weapon>
 		<Name>LeftMG</Name>
 		<AttackRate>0.25</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
+		<DamagePerSecond>100</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_machinegun_01</Projectile>
 		<ImpactEffect size="Small">unsc_rifle_01</ImpactEffect>


### PR DESCRIPTION
The Laser and Rocket on the Hawk and Hornet respectively have been disconnected to allow them to be used on different unit types separately.

The Elephant gets a damage buff when the additional turrets upgrade happens.