### PR TITLE
Hwde oprb v0.0.16

### DIFF
--- a/data/leaders.xml
+++ b/data/leaders.xml
@@ -23,8 +23,8 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<Pop Type="Unit" Max="200">200</Pop>
-		<Pop Type="Spartan" Max="3">3</Pop>
+		<Pop Type="Unit" Max="200">120</Pop>
+		<Pop Type="Spartan" Max="6">6</Pop>
 	</Leader>
 	<Leader Name="Forge" Icon="ui\game\icon\unsc\leader\Sergeant Forge" LeaderPickerOrder="3" StatsID="2" DefaultPlayerSlotFlags="0x2">
 		<Civ>UNSC</Civ>
@@ -48,8 +48,8 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<Pop Type="Unit" Max="200">200</Pop>
-		<Pop Type="Spartan" Max="3">3</Pop>
+		<Pop Type="Unit" Max="200">120</Pop>
+		<Pop Type="Spartan" Max="6">6</Pop>
 	</Leader>
 	<Leader Name="Anders" Icon="ui\game\icon\unsc\leader\Serina" Alpha="0" LeaderPickerOrder="4" StatsID="3" DefaultPlayerSlotFlags="0x4">
 		<Civ>UNSC</Civ>
@@ -73,8 +73,8 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<Pop Type="Unit" Max="200">200</Pop>
-		<Pop Type="Spartan" Max="3">3</Pop>
+		<Pop Type="Unit" Max="200">120</Pop>
+		<Pop Type="Spartan" Max="6">6</Pop>
 	</Leader>
 	<Leader Name="Random UNSC" LeaderPickerOrder="1" Random="true">
 		<Civ>UNSC</Civ>
@@ -104,8 +104,8 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<ReverseHotDropCost Type="Supplies">100</ReverseHotDropCost>
-		<Pop Type="Unit" Max="200">200</Pop>
+		<ReverseHotDropCost Type="Supplies">600</ReverseHotDropCost>
+		<Pop Type="Unit" Max="200">120</Pop>
 		<Pop Type="Leader" Max="1">1</Pop>
 		<Pop Type="Temple" Max="1">1</Pop>
 	</Leader>
@@ -129,8 +129,8 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<ReverseHotDropCost Type="Supplies">100</ReverseHotDropCost>
-		<Pop Type="Unit" Max="200">200</Pop>
+		<ReverseHotDropCost Type="Supplies">600</ReverseHotDropCost>
+		<Pop Type="Unit" Max="200">120</Pop>
 		<Pop Type="Temple" Max="1">1</Pop>
 		<Pop Type="Leader" Max="1">1</Pop>
 	</Leader>
@@ -154,8 +154,8 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<ReverseHotDropCost Type="Supplies">100</ReverseHotDropCost>
-		<Pop Type="Unit" Max="200">200</Pop>
+		<ReverseHotDropCost Type="Supplies">600</ReverseHotDropCost>
+		<Pop Type="Unit" Max="200">120</Pop>
 		<Pop Type="Leader" Max="1">1</Pop>
 		<Pop Type="Temple" Max="1">1</Pop>
 	</Leader>
@@ -192,7 +192,7 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<Pop Type="Unit" Max="200">200</Pop>
+		<Pop Type="Unit" Max="200">120</Pop>
 	</Leader>
 	<Leader Name="Prophet of Pudding" Icon="ui\game\icon\covenant\leader\Prophet of truth" Test="true" Alpha="0">
 		<Civ>Covenant</Civ>
@@ -211,7 +211,7 @@
 		<RepairDelay>20</RepairDelay>
 		<RepairCost Type="Supplies">35</RepairCost>
 		<RepairTime>30</RepairTime>
-		<Pop Type="Unit" Max="200">200</Pop>
+		<Pop Type="Unit" Max="200">120</Pop>
 		<Pop Type="Temple" Max="1">1</Pop>
 	</Leader>
 </Leaders>

--- a/data/objects.xml
+++ b/data/objects.xml
@@ -6281,7 +6281,7 @@
 		<Hardpoint name="Turret" autocenter="true" yawrate="360" pitchrate="180" pitchMinAngle="-30" pitchMaxAngle="60" yawattachment="empgun" pitchattachment="empgun" />
 		<Velocity>18</Velocity>
 		<TurnRate>120</TurnRate>
-		<Hitpoints>1200</Hitpoints>
+		<Hitpoints>2500</Hitpoints>
 		<AttackGradeDPS>136.800003</AttackGradeDPS>
 		<CombatValue>8</CombatValue>
 		<Veterancy Level="1" XP="16" Damage="1.14999998" Velocity="1" Accuracy="1.60000002" WorkRate="1.20000005" WeaponRange="1" DamageTaken="0.870000005" />

--- a/data/powers.xml
+++ b/data/powers.xml
@@ -50,8 +50,8 @@
 				<Data type="sound" name="HudLastFireSound">play_unsc_transport_vo_dropoff</Data>
 				<Data type="sound" name="HudStartEnvSound">hud_mac_open</Data>
 				<Data type="sound" name="HudStopEnvSound">hud_mac_close</Data>
-				<Data type="int" name="MaxGroundVehicles">3</Data>
-				<Data type="int" name="MaxInfantryUnits">6</Data>
+				<Data type="int" name="MaxGroundVehicles">6</Data>
+				<Data type="int" name="MaxInfantryUnits">12</Data>
 				<Data type="texture" name="Base">ui\flash\shared\textures\powers\TransportBase</Data>
 				<Data type="texture" name="Mover">ui\flash\shared\textures\powers\TransportMover</Data>
 				<Data type="float" name="MinTransportDistance">45</Data>
@@ -93,7 +93,7 @@
 				<Data type="float" name="MinBeamDistance">0</Data>
 				<Data type="float" name="MaxBeamDistance">100</Data>
 				<Data type="float" name="TickLength">0.200000003</Data>
-				<Data type="float" name="SuppliesPerTick">30</Data>
+				<Data type="float" name="SuppliesPerTick">10</Data>
 				<Data type="float" name="CommandInterval">0.200000003</Data>
 				<Data type="float" name="MaxBeamSpeed">20</Data>
 			</BaseDataLevel>
@@ -135,7 +135,7 @@
 				<Data type="float" name="TickLength">0.200000003</Data>
 				<Data type="float" name="SuppliesPerTick">1.25</Data>
 				<Data type="float" name="SuppliesPerTickAttacking">5</Data>
-				<Data type="float" name="SuppliesPerJump">40</Data>
+				<Data type="float" name="SuppliesPerJump">10</Data>
 				<Data type="float" name="CommandInterval">0.100000001</Data>
 				<Data type="float" name="TeleportTime">0.300000012</Data>
 				<Data type="float" name="TeleportLateralDistance">5</Data>
@@ -177,16 +177,16 @@
 				<Data type="float" name="HealPerKillCombatValue">150</Data>
 				<Data type="float" name="SuppliesPerTick">1</Data>
 				<Data type="float" name="SuppliesPerTickAttacking">4</Data>
-				<Data type="float" name="SuppliesPerJump">30</Data>
+				<Data type="float" name="SuppliesPerJump">10</Data>
 				<Data type="float" name="NudgeMultiplier">1.5</Data>
 				<Data type="float" name="DamageTakenMultiplier">1.75</Data>
 			</DataLevel>
 			<DataLevel level="3">
-				<Data type="float" name="SpeedMultiplier">2</Data>
-				<Data type="float" name="HealPerKillCombatValue">150</Data>
+				<Data type="float" name="SpeedMultiplier">3</Data>
+				<Data type="float" name="HealPerKillCombatValue">350</Data>
 				<Data type="float" name="SuppliesPerTick">1</Data>
-				<Data type="float" name="SuppliesPerTickAttacking">4</Data>
-				<Data type="float" name="SuppliesPerJump">30</Data>
+				<Data type="float" name="SuppliesPerTickAttacking">10</Data>
+				<Data type="float" name="SuppliesPerJump">10</Data>
 				<Data type="float" name="AuraRadius">60</Data>
 				<Data type="float" name="AuraDamageBonus">1.25</Data>
 				<Data type="float" name="NudgeMultiplier">1.75</Data>
@@ -212,7 +212,7 @@
 			<CameraEffectOut>WavePowerToNormal</CameraEffectOut>
 			<BaseDataLevel>
 				<Data type="float" name="TickLength">0.200000003</Data>
-				<Data type="float" name="SuppliesPerTick">30</Data>
+				<Data type="float" name="SuppliesPerTick">10</Data>
 				<Data type="float" name="CommandInterval">0.200000003</Data>
 				<Data type="float" name="HintTime">1</Data>
 				<Data type="float" name="MinBallDistance">0</Data>

--- a/data/tactics/pow_proj_carpetbomb_01.tactics
+++ b/data/tactics/pow_proj_carpetbomb_01.tactics
@@ -3,13 +3,13 @@
 	<Weapon>
 		<Name>CarpetBomb</Name>
 		<AllowFriendlyFire />
-		<DamagePerSecond>3500</DamagePerSecond>
+		<DamagePerSecond>4500</DamagePerSecond>
 		<UseDPSasDPA />
 		<WeaponType>LeaderPower</WeaponType>
 		<Projectile>pow_proj_cleansing_01</Projectile>
 		<ImpactCameraShake duration="0.200000003" strength="0.200000003" />
 		<ImpactRumble leftRumbleType="Fixed" leftStrength="0.200000003" rightRumbleType="Fixed" rightStrength="0.200000003" duration="0.200000003" />
-		<AOERadius>10</AOERadius>
+		<AOERadius>20</AOERadius>
 		<AOEPrimaryTargetFactor>0</AOEPrimaryTargetFactor>
 		<AOEDistanceFactor>0.5</AOEDistanceFactor>
 		<AOEDamageFactor>0.5</AOEDamageFactor>

--- a/data/tactics/unsc_veh_gremlin_01.tactics
+++ b/data/tactics/unsc_veh_gremlin_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>laserCannon</Name>
 		<AttackRate>0.25</AttackRate>
-		<DamagePerSecond>170</DamagePerSecond>
+		<DamagePerSecond>225</DamagePerSecond>
 		<WeaponType>ArmorPiercing</WeaponType>
 		<Projectile>fx_proj_spartanlaser_01</Projectile>
 		<ImpactEffect size="Medium">unsc_spartanlaser_01</ImpactEffect>

--- a/data/techs.xml
+++ b/data/techs.xml
@@ -1391,13 +1391,13 @@
 		<RolloverTextID>1163</RolloverTextID>
 		<PrereqTextID>231</PrereqTextID>
 		<Cost resourcetype="Supplies">800</Cost>
-		<Cost resourcetype="Power">3</Cost>
+		<Cost resourcetype="Power">4</Cost>
 		<ResearchPoints>60</ResearchPoints>
 		<Status>OBTAINABLE</Status>
 		<Icon>ui\flash\HUD\hud_menu\hud_menu_icons\final_cov\placeholder</Icon>
 		<ResearchCompleteSound>play_vog_tech_reinforcements</ResearchCompleteSound>
 		<Effects>
-			<Effect type="Data" subtype="PopCap" amount="10" popType="Unit" relativity="Absolute">
+			<Effect type="Data" subtype="PopCap" amount="80" popType="Unit" relativity="Absolute">
 				<Target type="Player" />
 			</Effect>
 		</Effects>
@@ -5498,7 +5498,7 @@
 		<Icon>ui\flash\HUD\hud_menu\hud_menu_icons\final_cov\placeholder</Icon>
 		<ResearchCompleteSound>play_vog_tech_followers</ResearchCompleteSound>
 		<Effects>
-			<Effect type="Data" subtype="PopCap" amount="10" popType="Unit" relativity="Absolute">
+			<Effect type="Data" subtype="PopCap" amount="80" popType="Unit" relativity="Absolute">
 				<Target type="Player" />
 			</Effect>
 		</Effects>


### PR DESCRIPTION
- Gremlin was overly nerfed in the last patch and regains ~2000 health and a more poweful gun. More like a demigod than the god of death it was in v0.0.14.
- Forge Carpet Bomb gets a damage and AOE buff to bring it in line with other UNSC powers.
- All Covenant leader powers are now cheaper to use.
- Leader recall now costs 600.
- Spartan count in MP goes up to 6 per UNSC leader.
- Starting pop count is now 120 and the reinforcements/followers upgrade now adds 80 to the pop count to make it worthwhile.