### PR TITLE
Hwde oprb v0.0.17

### DIFF
--- a/data/leaders.xml
+++ b/data/leaders.xml
@@ -17,7 +17,9 @@
 		<Resource Type="Collectable">0</Resource>
 		<Resource Type="Power">0</Resource>
 		<StartingUnit Offset="0,0,0" BuildOther="unsc_bldg_command_03" DoppleOnStart="true">game_base_socket_01</StartingUnit>
-		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_veh_elephant_01</StartingSquad>
+		<StartingSquad FlyIn="false" Offset="60,0,-20">unsc_veh_elephant_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_veh_warthog_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_veh_warthog_01</StartingSquad>
 		<RallyPointOffset>50,0,0</RallyPointOffset>
 		<RepairRate>1</RepairRate>
 		<RepairDelay>20</RepairDelay>
@@ -68,6 +70,7 @@
 		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_veh_gremlin_01</StartingSquad>
 		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_inf_marine_01</StartingSquad>
 		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_inf_marine_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">unsc_inf_marine_01</StartingSquad>
 		<RallyPointOffset>50,0,0</RallyPointOffset>
 		<RepairRate>1</RepairRate>
 		<RepairDelay>20</RepairDelay>
@@ -98,7 +101,9 @@
 		<Resource Type="CampaignFoo">0</Resource>
 		<Resource Type="Power">0</Resource>
 		<StartingUnit Offset="0,0,0" BuildOther="cov_bldg_builder_02" DoppleOnStart="true">game_base_socket_01</StartingUnit>
-		<StartingSquad FlyIn="false" Offset="60,0,-20">cov_veh_ghost_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_veh_locust_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_veh_locust_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_veh_locust_01</StartingSquad>
 		<RallyPointOffset>50,0,0</RallyPointOffset>
 		<RepairRate>1</RepairRate>
 		<RepairDelay>20</RepairDelay>
@@ -123,7 +128,11 @@
 		<Resource Type="CampaignFoo">0</Resource>
 		<Resource Type="Power">0</Resource>
 		<StartingUnit Offset="0,0,0" BuildOther="cov_bldg_builder_02" DoppleOnStart="true">game_base_socket_01</StartingUnit>
-		<StartingSquad FlyIn="false" Offset="60,0,-20">cov_veh_bruteChopper_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_brute_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_brute_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_brute_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_brute_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_veh_bruteChopper_01</StartingSquad>
 		<RallyPointOffset>50,0,0</RallyPointOffset>
 		<RepairRate>1</RepairRate>
 		<RepairDelay>20</RepairDelay>
@@ -148,7 +157,13 @@
 		<Resource Type="CampaignFoo">0</Resource>
 		<Resource Type="Power">0</Resource>
 		<StartingUnit Offset="0,0,0" BuildOther="cov_bldg_builder_02" DoppleOnStart="true">game_base_socket_01</StartingUnit>
-		<StartingSquad FlyIn="false" Offset="60,0,-20">cov_veh_ghost_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_eliteCommando_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_eliteCommando_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_eliteCommando_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_eliteCommando_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_eliteCommando_01</StartingSquad>
+		<StartingSquad FlyIn="true" Offset="60,0,-20">cov_inf_eliteCommando_01</StartingSquad>
+
 		<RallyPointOffset>50,0,0</RallyPointOffset>
 		<RepairRate>1</RepairRate>
 		<RepairDelay>20</RepairDelay>

--- a/data/objects.xml
+++ b/data/objects.xml
@@ -9978,10 +9978,10 @@
 		<RolloverTextID>10127</RolloverTextID>
 		<RoleTextID>504</RoleTextID>
 		<MovementType>Land</MovementType>
-		<Velocity>15</Velocity>
+		<Velocity>10</Velocity>
 		<Acceleration>26</Acceleration>
 		<TurnRate>210</TurnRate>
-		<Hitpoints>2439</Hitpoints>
+		<Hitpoints>4000</Hitpoints>
 		<AttackGradeDPS>90</AttackGradeDPS>
 		<CombatValue>4</CombatValue>
 		<LOS>55</LOS>
@@ -10511,7 +10511,7 @@
 		<Velocity>25</Velocity>
 		<Acceleration>26</Acceleration>
 		<TurnRate>540</TurnRate>
-		<Hitpoints>10000</Hitpoints>
+		<Hitpoints>15000</Hitpoints>
 		<Shieldpoints>4250</Shieldpoints>
 		<AttackGradeDPS>740</AttackGradeDPS>
 		<CombatValue>30</CombatValue>
@@ -10840,14 +10840,14 @@
 		<DisplayNameID>10158</DisplayNameID>
 		<RolloverTextID>10159</RolloverTextID>
 		<MovementType>Land</MovementType>
-		<Velocity>15</Velocity>
+		<Velocity>10</Velocity>
 		<TurnRate>180</TurnRate>
-		<Shieldpoints>3000</Shieldpoints>
-		<Hitpoints>1333</Hitpoints>
+		<Shieldpoints>4000</Shieldpoints>
+		<Hitpoints>1000</Hitpoints>
 		<AttackGradeDPS>252</AttackGradeDPS>
 		<Hardpoint name="Turret" autocenter="true" yawrate="90" pitchrate="90" pitchMinAngle="-30" pitchMaxAngle="75" yawattachment="Turret" pitchattachment="Turret" />
 		<CombatValue>12</CombatValue>
-		<LOS>55</LOS>
+		<LOS>75</LOS>
 		<Pop Type="Unit">3</Pop>
 		<Bounty>12</Bounty>
 		<Veterancy Level="1" XP="24" Damage="1.14999998" Velocity="1" Accuracy="1.60000002" WorkRate="1.20000005" WeaponRange="1" DamageTaken="0.870000005" />
@@ -10915,13 +10915,13 @@
 		<DisplayNameID>10134</DisplayNameID>
 		<RolloverTextID>10135</RolloverTextID>
 		<MovementType>Land</MovementType>
-		<Velocity>40</Velocity>
+		<Velocity>50</Velocity>
 		<TurnRate>1100</TurnRate>
-		<Hitpoints>1492</Hitpoints>
+		<Hitpoints>1000</Hitpoints>
 		<Shieldpoints>0</Shieldpoints>
 		<AttackGradeDPS>85.5</AttackGradeDPS>
 		<CombatValue>4</CombatValue>
-		<LOS>75</LOS>
+		<LOS>85</LOS>
 		<Pop Type="Unit">1</Pop>
 		<Bounty>4</Bounty>
 		<Veterancy Level="1" XP="8" Damage="1.14999998" Velocity="1" Accuracy="1.60000002" WorkRate="1.20000005" WeaponRange="1" DamageTaken="0.870000005" />
@@ -11078,10 +11078,10 @@
 		<Hardpoint name="PlasmaTurret" autocenter="true" pitchrate="180" yawmaxangle="10" yawattachment="Turret" pitchattachment="Turret" />
 		<Velocity>35</Velocity>
 		<TurnRate>120</TurnRate>
-		<Hitpoints>3642</Hitpoints>
+		<Hitpoints>4000</Hitpoints>
 		<AttackGradeDPS>144</AttackGradeDPS>
 		<CombatValue>8</CombatValue>
-		<LOS>75</LOS>
+		<LOS>85</LOS>
 		<Pop Type="Unit">2</Pop>
 		<Bounty>8</Bounty>
 		<AmmoMax>1000</AmmoMax>
@@ -11151,10 +11151,10 @@
 		<DisplayNameID>10140</DisplayNameID>
 		<RolloverTextID>10141</RolloverTextID>
 		<MovementType>Air</MovementType>
-		<Velocity>25</Velocity>
+		<Velocity>35</Velocity>
 		<ReverseSpeed>0.0f</ReverseSpeed>
 		<TurnRate>180</TurnRate>
-		<Hitpoints>3258</Hitpoints>
+		<Hitpoints>1800</Hitpoints>
 		<AttackGradeDPS>132</AttackGradeDPS>
 		<CombatValue>8</CombatValue>
 		<LOS>55</LOS>

--- a/data/squads.xml
+++ b/data/squads.xml
@@ -1182,8 +1182,8 @@
 		<RolloverTextID>3071</RolloverTextID>
 		<PrereqTextID>243</PrereqTextID>
 		<RoleTextID>507</RoleTextID>
-		<BuildPoints>23</BuildPoints>
-		<Cost resourcetype="Supplies">300</Cost>
+		<BuildPoints>18</BuildPoints>
+		<Cost resourcetype="Supplies">500</Cost>
 		<Cost resourcetype="Power">2</Cost>
 		<SubSelectSort>6300</SubSelectSort>
 		<LeashDistance>15</LeashDistance>
@@ -1213,7 +1213,7 @@
 		<RolloverTextID>3061</RolloverTextID>
 		<PrereqTextID>246</PrereqTextID>
 		<RoleTextID>508</RoleTextID>
-		<BuildPoints>120</BuildPoints>
+		<BuildPoints>60</BuildPoints>
 		<LeashDistance>15</LeashDistance>
 		<LeashDeadzone>5</LeashDeadzone>
 		<LeashRecallDelay>2500</LeashRecallDelay>
@@ -1244,8 +1244,8 @@
 		<RolloverTextID>3057</RolloverTextID>
 		<PrereqTextID>242</PrereqTextID>
 		<RoleTextID>501</RoleTextID>
-		<BuildPoints>26</BuildPoints>
-		<Cost resourcetype="Supplies">350</Cost>
+		<BuildPoints>12</BuildPoints>
+		<Cost resourcetype="Supplies">300</Cost>
 		<Cost resourcetype="Power">1</Cost>
 		<SubSelectSort>6500</SubSelectSort>
 		<LeashDistance>20</LeashDistance>
@@ -1274,7 +1274,7 @@
 		<RolloverTextID>3085</RolloverTextID>
 		<PrereqTextID>240</PrereqTextID>
 		<RoleTextID>518</RoleTextID>
-		<BuildPoints>15</BuildPoints>
+		<BuildPoints>8</BuildPoints>
 		<Cost resourcetype="Supplies">200</Cost>
 		<SubSelectSort>620</SubSelectSort>
 		<LeashDistance>45</LeashDistance>
@@ -1312,7 +1312,7 @@
 		<RolloverTextID>3059</RolloverTextID>
 		<PrereqTextID>240</PrereqTextID>
 		<RoleTextID>518</RoleTextID>
-		<BuildPoints>8</BuildPoints>
+		<BuildPoints>6</BuildPoints>
 		<Cost resourcetype="Supplies">100</Cost>
 		<SubSelectSort>610</SubSelectSort>
 		<LeashDistance>45</LeashDistance>
@@ -1408,7 +1408,7 @@
 		<PrereqTextID>244</PrereqTextID>
 		<RoleTextID>520</RoleTextID>
 		<BuildPoints>60</BuildPoints>
-		<Cost resourcetype="Supplies">400</Cost>
+		<Cost resourcetype="Supplies">1500</Cost>
 		<SubSelectSort>2000</SubSelectSort>
 		<LeashDistance>20</LeashDistance>
 		<LeashDeadzone>40</LeashDeadzone>
@@ -1466,7 +1466,7 @@
 		<PrereqTextID>244</PrereqTextID>
 		<RoleTextID>520</RoleTextID>
 		<BuildPoints>60</BuildPoints>
-		<Cost resourcetype="Supplies">400</Cost>
+		<Cost resourcetype="Supplies">1500</Cost>
 		<SubSelectSort>2000</SubSelectSort>
 		<LeashDistance>80</LeashDistance>
 		<LeashDeadzone>40</LeashDeadzone>
@@ -1524,7 +1524,7 @@
 		<PrereqTextID>244</PrereqTextID>
 		<RoleTextID>520</RoleTextID>
 		<BuildPoints>60</BuildPoints>
-		<Cost resourcetype="Supplies">400</Cost>
+		<Cost resourcetype="Supplies">1500</Cost>
 		<SubSelectSort>2000</SubSelectSort>
 		<LeashDistance>35</LeashDistance>
 		<LeashDeadzone>5</LeashDeadzone>
@@ -2766,7 +2766,7 @@
 		<RoleTextID>504</RoleTextID>
 		<PrereqTextID>242</PrereqTextID>
 		<BuildPoints>20</BuildPoints>
-		<Cost resourcetype="Supplies">250</Cost>
+		<Cost resourcetype="Supplies">350</Cost>
 		<Cost resourcetype="Power">1</Cost>
 		<SubSelectSort>4700</SubSelectSort>
 		<LeashDistance>35</LeashDistance>

--- a/data/stringtable-en.xml
+++ b/data/stringtable-en.xml
@@ -312,7 +312,7 @@
 		<String _locID="1160" category="Techs" subtitle="false">MISSILE LAUNCHER</String>
 		<String _locID="1161" category="Techs" subtitle="false">Adds bonus Anti-Air attack to the Turret.</String>
 		<String _locID="1162" category="Techs" subtitle="false">REINFORCEMENTS</String>
-		<String _locID="1163" category="Techs" subtitle="false">Adds +10 to the population cap of your army.</String>
+		<String _locID="1163" category="Techs" subtitle="false">Adds +80 to the population cap of your army.</String>
 		<String _locID="1164" category="Techs" subtitle="false">AUTOCANNONS</String>
 		<String _locID="1165" category="Techs" subtitle="false">Adds front-firing 35mm guns, improving the Chopper's attack.</String>
 		<String _locID="1166" category="Techs" subtitle="false">STABILIZERS</String>
@@ -322,7 +322,7 @@
 		<String _locID="1170" category="Techs" subtitle="false">JUMP PACK ABILITY</String>
 		<String _locID="1171" category="Techs" subtitle="false">Enables the Jump Pack Ability, allowing Brutes to quickly cross the battlefield.</String>
 		<String _locID="1172" category="Techs" subtitle="false">FOLLOWERS</String>
-		<String _locID="1173" category="Techs" subtitle="false">Increases the maximum size of your army by 10.</String>
+		<String _locID="1173" category="Techs" subtitle="false">Increases the maximum size of your army by 80.</String>
 		<String _locID="1174" category="Techs" subtitle="false" />
 		<String _locID="1175" category="Techs" subtitle="false" />
 		<String _locID="3000" category="Squads" subtitle="false">MARINE</String>

--- a/data/tactics/cov_air_banshee_01.tactics
+++ b/data/tactics/cov_air_banshee_01.tactics
@@ -2,8 +2,8 @@
 <TacticData>
 	<Weapon>
 		<Name>PlasmaCannon</Name>
-		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>90</DamagePerSecond>
+		<AttackRate>1</AttackRate>
+		<DamagePerSecond>50</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_plasmaCannon_03</Projectile>
 		<ImpactEffect size="Medium">cov_plasmacannon_01</ImpactEffect>
@@ -18,8 +18,8 @@
 	</Weapon>
 	<Weapon>
 		<Name>FuelRodCannon</Name>
-		<AttackRate>4</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
+		<AttackRate>3</AttackRate>
+		<DamagePerSecond>100</DamagePerSecond>
 		<WeaponType>BansheeFuelRod</WeaponType>
 		<Projectile>fx_proj_fuelRod_01</Projectile>
 		<ImpactEffect size="Medium">fuelrod_01</ImpactEffect>
@@ -153,6 +153,8 @@
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
+			<TargetType>Infantry</TargetType>
+			<TargetType>Flying</TargetType>
 			<Action>PlasmaCannonAttackAction</Action>
 		</TargetRule>
 		<TargetRule>

--- a/data/tactics/cov_air_vampire_01.tactics
+++ b/data/tactics/cov_air_vampire_01.tactics
@@ -1,53 +1,9 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <TacticData>
 	<Weapon>
-		<Name>PlasmaCannonLeft</Name>
-		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
-		<WeaponType>SmallArms</WeaponType>
-		<Projectile>fx_proj_plasmaCannon_01</Projectile>
-		<ImpactEffect size="Medium">cov_plasmacannon_01</ImpactEffect>
-		<MaxVelocityLead>16</MaxVelocityLead>
-		<MaxRange>75</MaxRange>
-		<Hardpoint>PlasmaTurretLeft</Hardpoint>
-		<Accuracy>0.100000001</Accuracy>
-		<MaxDeviation>3</MaxDeviation>
-		<MovingAccuracy>0.0500000007</MovingAccuracy>
-		<MovingMaxDeviation>4.5</MovingMaxDeviation>
-		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
-		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
-		<TargetPriority type="Flying">10</TargetPriority>
-		<TargetPriority type="Infantry">4</TargetPriority>
-		<TargetPriority type="GroundVehicle">3</TargetPriority>
-		<TargetPriority type="TurretBuilding">0</TargetPriority>
-		<TargetPriority type="Building">-3</TargetPriority>
-	</Weapon>
-	<Weapon>
-		<Name>PlasmaCannonRight</Name>
-		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
-		<WeaponType>SmallArms</WeaponType>
-		<Projectile>fx_proj_plasmaCannon_01</Projectile>
-		<ImpactEffect size="Medium">cov_plasmacannon_01</ImpactEffect>
-		<MaxVelocityLead>16</MaxVelocityLead>
-		<MaxRange>75</MaxRange>
-		<Hardpoint>PlasmaTurretRight</Hardpoint>
-		<Accuracy>0.100000001</Accuracy>
-		<MaxDeviation>3</MaxDeviation>
-		<MovingAccuracy>0.0500000007</MovingAccuracy>
-		<MovingMaxDeviation>4.5</MovingMaxDeviation>
-		<AccuracyDistanceFactor>0.5</AccuracyDistanceFactor>
-		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
-		<TargetPriority type="Flying">10</TargetPriority>
-		<TargetPriority type="Infantry">4</TargetPriority>
-		<TargetPriority type="GroundVehicle">3</TargetPriority>
-		<TargetPriority type="TurretBuilding">0</TargetPriority>
-		<TargetPriority type="Building">-3</TargetPriority>
-	</Weapon>
-	<Weapon>
 		<Name>HeavyNeedler</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>70</DamagePerSecond>
+		<DamagePerSecond>140</DamagePerSecond>
 		<WeaponType>AntiAir</WeaponType>
 		<Projectile>fx_proj_heavyNeedler_01</Projectile>
 		<ImpactEffect size="Medium">cov_heavyneedler_01</ImpactEffect>
@@ -73,7 +29,7 @@
 	<Weapon>
 		<Name>StasisDrainBeam</Name>
 		<AttackRate>0.100000001</AttackRate>
-		<DamagePerSecond>30</DamagePerSecond>
+		<DamagePerSecond>10</DamagePerSecond>
 		<Stasis SmartTargeting="true" />
 		<StasisDrain />
 		<StasisHealToDrainRatio>1</StasisHealToDrainRatio>
@@ -91,7 +47,7 @@
 	<Weapon>
 		<Name>StasisBombBeam</Name>
 		<AttackRate>0.100000001</AttackRate>
-		<DamagePerSecond>30</DamagePerSecond>
+		<DamagePerSecond>50</DamagePerSecond>
 		<Stasis SmartTargeting="true" />
 		<StasisDrain />
 		<StasisBomb />
@@ -125,22 +81,6 @@
 		<PhysicsForceMax>1200</PhysicsForceMax>
 		<PhysicsForceMaxAngle>0.800000012</PhysicsForceMaxAngle>
 	</Weapon>
-	<Action>
-		<Name>PlasmaCannonRightAttackAction</Name>
-		<ActionType>RangedAttack</ActionType>
-		<PersistentActionType>SecondaryTurretAttack</PersistentActionType>
-		<Anim>PlasmaCannonRightAttack</Anim>
-		<Weapon>PlasmaCannonRight</Weapon>
-		<MainAttack />
-	</Action>
-	<Action>
-		<Name>PlasmaCannonLeftAttackAction</Name>
-		<ActionType>RangedAttack</ActionType>
-		<PersistentActionType>SecondaryTurretAttack</PersistentActionType>
-		<Anim>PlasmaCannonLeftAttack</Anim>
-		<Weapon>PlasmaCannonLeft</Weapon>
-		<MainAttack />
-	</Action>
 	<Action>
 		<Name>HeavyNeedlerAttackAction</Name>
 		<ActionType>RangedAttack</ActionType>
@@ -237,14 +177,6 @@
 			<Relation>Enemy</Relation>
 			<TargetType>Flying</TargetType>
 			<Action>HeavyNeedlerAttackAction</Action>
-		</TargetRule>
-		<TargetRule>
-			<Relation>Enemy</Relation>
-			<Action>PlasmaCannonRightAttackAction</Action>
-		</TargetRule>
-		<TargetRule>
-			<Relation>Enemy</Relation>
-			<Action>PlasmaCannonLeftAttackAction</Action>
 		</TargetRule>
 		<TargetRule>
 			<Ability>Command</Ability>

--- a/data/tactics/cov_inf_arbiter_01.tactics
+++ b/data/tactics/cov_inf_arbiter_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>DualSword</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>240</DamagePerSecond>
+		<DamagePerSecond>340</DamagePerSecond>
 		<WeaponType>leaderPower</WeaponType>
 		<MaxRange>3</MaxRange>
 		<Hardpoint>Torso</Hardpoint>

--- a/data/tactics/cov_inf_arbiter_02.tactics
+++ b/data/tactics/cov_inf_arbiter_02.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>DualSword</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>240</DamagePerSecond>
+		<DamagePerSecond>440</DamagePerSecond>
 		<WeaponType>leaderPower</WeaponType>
 		<MaxRange>3</MaxRange>
 		<Hardpoint>Torso</Hardpoint>

--- a/data/tactics/cov_inf_elite_01.tactics
+++ b/data/tactics/cov_inf_elite_01.tactics
@@ -54,8 +54,8 @@
 	</Weapon>
 	<Weapon>
 		<Name>PlasmaRifle</Name>
-		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>18.1499996</DamagePerSecond>
+		<AttackRate>0.75</AttackRate>
+		<DamagePerSecond>20</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_plasmaRifle_01</Projectile>
 		<ImpactEffect size="small">cov_plasmarifle_01</ImpactEffect>

--- a/data/tactics/cov_inf_grunt_01.tactics
+++ b/data/tactics/cov_inf_grunt_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>InCoverPlasmaPistol</Name>
 		<AttackRate>1</AttackRate>
-		<DamagePerSecond>17.6000004</DamagePerSecond>
+		<DamagePerSecond>20</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_plasmaPistol_01</Projectile>
 		<ImpactEffect size="small">cov_plasmapistol_01</ImpactEffect>
@@ -56,7 +56,7 @@
 	<Weapon>
 		<Name>PlasmaPistol</Name>
 		<AttackRate>1</AttackRate>
-		<DamagePerSecond>8.80000019</DamagePerSecond>
+		<DamagePerSecond>15</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_plasmaPistol_01</Projectile>
 		<ImpactEffect size="small">cov_plasmapistol_01</ImpactEffect>
@@ -79,7 +79,7 @@
 	<Weapon>
 		<Name>Grenade</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>280</DamagePerSecond>
+		<DamagePerSecond>380</DamagePerSecond>
 		<UseDPSasDPA />
 		<WeaponType>Grenade</WeaponType>
 		<Projectile>fx_proj_plasmaGrenade_01</Projectile>

--- a/data/tactics/cov_inf_hunter_01.tactics
+++ b/data/tactics/cov_inf_hunter_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>FuelRodCannon</Name>
 		<AttackRate>4</AttackRate>
-		<DamagePerSecond>90</DamagePerSecond>
+		<DamagePerSecond>120</DamagePerSecond>
 		<WeaponType>FuelRod</WeaponType>
 		<Projectile>fx_proj_fuelRod_01</Projectile>
 		<ImpactEffect size="Medium">fuelrod_01</ImpactEffect>
@@ -36,7 +36,7 @@
 	<Weapon>
 		<Name>BeamCannon</Name>
 		<AttackRate>4</AttackRate>
-		<DamagePerSecond>90</DamagePerSecond>
+		<DamagePerSecond>150</DamagePerSecond>
 		<WeaponType>FuelRod</WeaponType>
 		<Projectile>fx_hunterbeam</Projectile>
 		<ImpactEffect size="Medium">fuelrod_01</ImpactEffect>

--- a/data/tactics/cov_inf_needlergrunt_01.tactics
+++ b/data/tactics/cov_inf_needlergrunt_01.tactics
@@ -48,7 +48,7 @@
 	<Weapon>
 		<Name>Needler</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>8.80000019</DamagePerSecond>
+		<DamagePerSecond>12</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_needler_01</Projectile>
 		<ImpactEffect size="small">needler_01</ImpactEffect>
@@ -63,7 +63,7 @@
 	<Weapon>
 		<Name>Grenade</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>280</DamagePerSecond>
+		<DamagePerSecond>380</DamagePerSecond>
 		<UseDPSasDPA />
 		<WeaponType>Grenade</WeaponType>
 		<Projectile>fx_proj_plasmaGrenade_01</Projectile>

--- a/data/tactics/cov_inf_prophet_01.tactics
+++ b/data/tactics/cov_inf_prophet_01.tactics
@@ -34,7 +34,7 @@
 	</Weapon>
 	<Weapon>
 		<Name>plasmaCannon</Name>
-		<AttackRate>1</AttackRate>
+		<AttackRate>2</AttackRate>
 		<DamagePerSecond>200</DamagePerSecond>
 		<WeaponType>SmallArms</WeaponType>
 		<Projectile>fx_proj_plasmaRifle_01</Projectile>

--- a/data/tactics/cov_inf_prophet_02.tactics
+++ b/data/tactics/cov_inf_prophet_02.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>FuelRodCannon</Name>
 		<AttackRate>4</AttackRate>
-		<DamagePerSecond>200</DamagePerSecond>
+		<DamagePerSecond>300</DamagePerSecond>
 		<WeaponType>leaderPower</WeaponType>
 		<Projectile>fx_proj_prophetFuelRod_01</Projectile>
 		<ImpactEffect size="Medium">fuelrod_01</ImpactEffect>

--- a/data/tactics/cov_veh_brutechopper_01.tactics
+++ b/data/tactics/cov_veh_brutechopper_01.tactics
@@ -3,7 +3,7 @@
 	<Weapon>
 		<Name>PlasmaCannon</Name>
 		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>120</DamagePerSecond>
+		<DamagePerSecond>220</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_bruteGun_01</Projectile>
 		<ImpactEffect size="Medium">cov_brutechopper_01</ImpactEffect>
@@ -23,7 +23,7 @@
 	</Weapon>
 	<Weapon>
 		<Name>Ram</Name>
-		<DamagePerSecond>500</DamagePerSecond>
+		<DamagePerSecond>2000</DamagePerSecond>
 		<WeaponType>WarthogRam</WeaponType>
 		<MaxRange>5</MaxRange>
 		<AOERadius>40</AOERadius>

--- a/data/tactics/cov_veh_ghost_01.tactics
+++ b/data/tactics/cov_veh_ghost_01.tactics
@@ -22,7 +22,7 @@
 	</Weapon>
 	<Weapon>
 		<Name>Ram</Name>
-		<DamagePerSecond>500</DamagePerSecond>
+		<DamagePerSecond>1500</DamagePerSecond>
 		<WeaponType>WarthogRam</WeaponType>
 		<MaxRange>5</MaxRange>
 		<AOERadius>40</AOERadius>

--- a/data/tactics/cov_veh_locust_01.tactics
+++ b/data/tactics/cov_veh_locust_01.tactics
@@ -3,12 +3,12 @@
 	<Weapon>
 		<Name>chimeraBeam</Name>
 		<AttackRate>0.100000001</AttackRate>
-		<DamagePerSecond>226.800003</DamagePerSecond>
+		<DamagePerSecond>150</DamagePerSecond>
 		<WeaponType>Beam</WeaponType>
 		<Projectile>fx_proj_chimeraBeam_01</Projectile>
 		<ImpactEffect size="Medium">Tankshell</ImpactEffect>
 		<MaxVelocityLead>4</MaxVelocityLead>
-		<MaxRange>120</MaxRange>
+		<MaxRange>70</MaxRange>
 		<Hardpoint>Turret</Hardpoint>
 		<EnableHeightBonusDamage />
 		<AOERadius>6</AOERadius>
@@ -29,13 +29,13 @@
 	<Weapon>
 		<Name>OverburnBeam</Name>
 		<AttackRate>0.100000001</AttackRate>
-		<DamagePerSecond>226.800003</DamagePerSecond>
-		<DPSRamp startDPSPercent="100" finalDPSPercent="175" rampTime="5.0f" shieldDrain="true" />
+		<DamagePerSecond>250</DamagePerSecond>
+		<DPSRamp startDPSPercent="50" finalDPSPercent="250" rampTime="15.0f" shieldDrain="true" />
 		<WeaponType>Beam</WeaponType>
 		<Projectile>fx_proj_overdrivebeam_01</Projectile>
 		<ImpactEffect size="Medium">Tankshell</ImpactEffect>
 		<MaxVelocityLead>4</MaxVelocityLead>
-		<MaxRange>120</MaxRange>
+		<MaxRange>75</MaxRange>
 		<Hardpoint>Turret</Hardpoint>
 		<EnableHeightBonusDamage />
 		<AOERadius>8</AOERadius>

--- a/data/tactics/cov_veh_wraith_01.tactics
+++ b/data/tactics/cov_veh_wraith_01.tactics
@@ -2,8 +2,8 @@
 <TacticData>
 	<Weapon>
 		<Name>PlasmaCannon</Name>
-		<AttackRate>0.5</AttackRate>
-		<DamagePerSecond>60</DamagePerSecond>
+		<AttackRate>1</AttackRate>
+		<DamagePerSecond>70</DamagePerSecond>
 		<WeaponType>AASmallArms</WeaponType>
 		<Projectile>fx_proj_plasmaCannon_01</Projectile>
 		<ImpactEffect size="Medium">cov_plasmacannon_01</ImpactEffect>
@@ -18,10 +18,6 @@
 		<AccuracyDeviationFactor>0.330000013</AccuracyDeviationFactor>
 		<EnableHeightBonusDamage />
 		<TargetPriority type="Infantry">10</TargetPriority>
-		<TargetPriority type="Aircraft">7</TargetPriority>
-		<TargetPriority type="GroundVehicle">5</TargetPriority>
-		<TargetPriority type="TurretBuilding">3</TargetPriority>
-		<TargetPriority type="Building">1</TargetPriority>
 	</Weapon>
 	<Weapon>
 		<Name>PlasmaMortar</Name>
@@ -185,6 +181,8 @@
 		</TargetRule>
 		<TargetRule>
 			<Relation>Enemy</Relation>
+			<TargetType>Infantry</TargetType>
+			<TargetType>Flying</TargetType>
 			<Action>PlasmaCannonAttackAction</Action>
 		</TargetRule>
 		<TargetRule>

--- a/data/techs.xml
+++ b/data/techs.xml
@@ -4673,7 +4673,7 @@
 			<Effect type="Data" amount="1.25" subtype="AmmoRegenRate" relativity="Percent">
 				<Target type="ProtoUnit">cov_veh_ghost_01</Target>
 			</Effect>
-			<Effect type="Data" amount="1200" subtype="Shieldpoints" relativity="Absolute">
+			<Effect type="Data" amount="2200" subtype="Shieldpoints" relativity="Absolute">
 				<Target type="ProtoUnit">cov_veh_ghost_01</Target>
 			</Effect>
 			<Effect type="Data" hpbar="Cov_HealthShield" subtype="HPBar" relativity="Absolute">


### PR DESCRIPTION
- Wraith cost and build time decrease
- Wraith Plasma cannon damage buff
- Wraith can only shoot at Infantry and Air with Plasma Cannon
- Banshee won't use Plasma Cannon against Buildings, gets a Fuel Rod buff in kind.
- All Covenant Leaders get new starting units to help make rush more viable.
- All Covenant Leaders get a health buff.
- Prophet and Arbiter get damage buffs.
- Ghost and Banshee get faster.
- All Covenant Units with shield upgrades lose health but now have more shields.
- Build time for Ghost decreased.
- Covenant rams are now quite powerful.
- Scarab build time halved to balance it against the better units it now faces.
- Hunters have a health and damage buff to make them behave more like in the Halo FPS.
- Elite Squads get damage buff.